### PR TITLE
Fix: profile editing bug that wipes it

### DIFF
--- a/foqos.xcodeproj/project.pbxproj
+++ b/foqos.xcodeproj/project.pbxproj
@@ -568,7 +568,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 1.9;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -616,7 +616,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 1.9;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/foqos/Views/HomeView.swift
+++ b/foqos/Views/HomeView.swift
@@ -20,7 +20,12 @@ struct HomeView: View {
     @State private var activeProfile: BlockedProfiles? = nil
     @State private var profileIndex = 0
     @State private var isProfileListPresent = false
-    @State private var showActiveProfileView = false
+
+    // New profile view
+    @State private var showNewProfileView = false
+
+    // Edit profile
+    @State private var profileToEdit: BlockedProfiles? = nil
 
     // Activity sessions
     @Query(sort: \BlockedProfileSession.startTime, order: .reverse) private
@@ -98,7 +103,7 @@ struct HomeView: View {
 
                 if profiles.isEmpty {
                     Welcome(onTap: {
-                        showActiveProfileView = true
+                        showNewProfileView = true
                     })
                     .padding(.horizontal, 16)
                 }
@@ -125,8 +130,7 @@ struct HomeView: View {
                             strategyButtonPress()
                         },
                         onEditTapped: { profile in
-                            activeProfile = profile
-                            showActiveProfileView = true
+                            profileToEdit = profile
                         },
                         onBreakTapped: { _ in
                             strategyManager.toggleBreak()
@@ -219,9 +223,15 @@ struct HomeView: View {
             IntroView {
                 requestAuthorizer.requestAuthorization()
             }.interactiveDismissDisabled()
-        }.sheet(isPresented: $showActiveProfileView) {
-            BlockedProfileView(profile: activeProfile)
-        }.sheet(isPresented: $strategyManager.showCustomStrategyView) {
+        }.sheet(item: $profileToEdit) { profile in
+            BlockedProfileView(profile: profile)
+        }
+        .sheet(
+            isPresented: $showNewProfileView,
+        ) {
+            BlockedProfileView(profile: nil)
+        }
+        .sheet(isPresented: $strategyManager.showCustomStrategyView) {
             BlockingStrategyActionView(
                 customView: strategyManager.customStrategyView
             )
@@ -235,18 +245,6 @@ struct HomeView: View {
 
     private func toggleSessionFromDeeplink(_ profileId: String) {
         strategyManager.toggleSessionFromDeeplink(profileId, context: context)
-    }
-
-    private func incrementProfiles() {
-        guard !profiles.isEmpty else { return }
-
-        profileIndex = (profileIndex + 1) % profiles.count
-    }
-
-    private func decrementProfiles() {
-        guard !profiles.isEmpty else { return }
-
-        profileIndex = (profileIndex - 1 + profiles.count) % profiles.count
     }
 
     private func strategyButtonPress() {


### PR DESCRIPTION
Fixes: #31 

## What's changed
- Live activities now store in app storage when they are active
- Updated bug where profiles were wiped