### PR TITLE
Disabling ability to write to new NFC tag or generate QR Code when in blocking

### DIFF
--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -204,6 +204,13 @@ struct BlockedProfileView: View {
                             }
                         }
                         .disabled(isBlocking)
+                        
+                        if isBlocking {
+                            Text("Disable current session to change")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.top, 4)
+                        }
                     }
                 }
 

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -192,6 +192,7 @@ struct BlockedProfileView: View {
                                 Spacer()
                             }
                         }
+                        .disabled(isBlocking)
 
                         Button(action: {
                             showingGeneratedQRCode = true
@@ -202,6 +203,7 @@ struct BlockedProfileView: View {
                                 Spacer()
                             }
                         }
+                        .disabled(isBlocking)
                     }
                 }
 


### PR DESCRIPTION
Hey Ali ! 

When blocked, its currently still possible to generate a QR code, screenshot it, then in photos app unblock the session using the new QR code. This makes it really easy to end the blocking session. 

![image](https://github.com/user-attachments/assets/efbfea81-656a-4402-967c-3fb688687b83)


I do not know if there is a break glass function in the app or if this is the break glass function but I can really easily turn off foqus currently and I'm hoping this PR can help stop that. 

PS: I don't have a apple dev license, so I haven't tested this change. 