### PR TITLE
Feature: Set custom reminder

### DIFF
--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -16,7 +16,7 @@ class BlockedProfiles {
 
   var enableLiveActivity: Bool = false
   var reminderTimeInSeconds: UInt32?
-  var customReminderMessage: String?
+  var customReminderMessage: String
   var enableBreaks: Bool = false
   var enableStrictMode: Bool = false
   var enableAllowMode: Bool = false
@@ -46,7 +46,7 @@ class BlockedProfiles {
     blockingStrategyId: String = NFCBlockingStrategy.id,
     enableLiveActivity: Bool = false,
     reminderTimeInSeconds: UInt32? = nil,
-    customReminderMessage: String? = nil,
+    customReminderMessage: String = "",
     enableBreaks: Bool = false,
     enableStrictMode: Bool = false,
     enableAllowMode: Bool = false,
@@ -120,7 +120,7 @@ class BlockedProfiles {
     blockingStrategyId: String? = nil,
     enableLiveActivity: Bool? = nil,
     reminderTime: UInt32? = nil,
-    customReminderMessage: String? = nil,
+    customReminderMessage: String = "",
     enableBreaks: Bool? = nil,
     enableStrictMode: Bool? = nil,
     enableAllowMode: Bool? = nil,
@@ -296,7 +296,7 @@ class BlockedProfiles {
     blockingStrategyId: String = NFCBlockingStrategy.id,
     enableLiveActivity: Bool = false,
     reminderTimeInSeconds: UInt32? = nil,
-    customReminderMessage: String? = nil,
+    customReminderMessage: String = "",
     enableBreaks: Bool = false,
     enableStrictMode: Bool = false,
     enableAllowMode: Bool = false,

--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -16,6 +16,7 @@ class BlockedProfiles {
 
   var enableLiveActivity: Bool = false
   var reminderTimeInSeconds: UInt32?
+  var customReminderMessage: String?
   var enableBreaks: Bool = false
   var enableStrictMode: Bool = false
   var enableAllowMode: Bool = false
@@ -45,6 +46,7 @@ class BlockedProfiles {
     blockingStrategyId: String = NFCBlockingStrategy.id,
     enableLiveActivity: Bool = false,
     reminderTimeInSeconds: UInt32? = nil,
+    customReminderMessage: String? = nil,
     enableBreaks: Bool = false,
     enableStrictMode: Bool = false,
     enableAllowMode: Bool = false,
@@ -66,6 +68,7 @@ class BlockedProfiles {
 
     self.enableLiveActivity = enableLiveActivity
     self.reminderTimeInSeconds = reminderTimeInSeconds
+    self.customReminderMessage = customReminderMessage
     self.enableLiveActivity = enableLiveActivity
     self.enableBreaks = enableBreaks
     self.enableStrictMode = enableStrictMode
@@ -117,6 +120,7 @@ class BlockedProfiles {
     blockingStrategyId: String? = nil,
     enableLiveActivity: Bool? = nil,
     reminderTime: UInt32? = nil,
+    customReminderMessage: String? = nil,
     enableBreaks: Bool? = nil,
     enableStrictMode: Bool? = nil,
     enableAllowMode: Bool? = nil,
@@ -181,7 +185,7 @@ class BlockedProfiles {
     profile.physicalUnblockQRCodeId = physicalUnblockQRCodeId
 
     profile.reminderTimeInSeconds = reminderTime
-
+    profile.customReminderMessage = customReminderMessage
     profile.updatedAt = Date()
 
     // Update the snapshot
@@ -242,6 +246,7 @@ class BlockedProfiles {
       order: profile.order,
       enableLiveActivity: profile.enableLiveActivity,
       reminderTimeInSeconds: profile.reminderTimeInSeconds,
+      customReminderMessage: profile.customReminderMessage,
       enableBreaks: profile.enableBreaks,
       enableStrictMode: profile.enableStrictMode,
       enableAllowMode: profile.enableAllowMode,
@@ -291,6 +296,7 @@ class BlockedProfiles {
     blockingStrategyId: String = NFCBlockingStrategy.id,
     enableLiveActivity: Bool = false,
     reminderTimeInSeconds: UInt32? = nil,
+    customReminderMessage: String? = nil,
     enableBreaks: Bool = false,
     enableStrictMode: Bool = false,
     enableAllowMode: Bool = false,
@@ -309,6 +315,7 @@ class BlockedProfiles {
       blockingStrategyId: blockingStrategyId,
       enableLiveActivity: enableLiveActivity,
       reminderTimeInSeconds: reminderTimeInSeconds,
+      customReminderMessage: customReminderMessage,
       enableBreaks: enableBreaks,
       enableStrictMode: enableStrictMode,
       enableAllowMode: enableAllowMode,
@@ -344,6 +351,7 @@ class BlockedProfiles {
       blockingStrategyId: source.blockingStrategyId ?? NFCBlockingStrategy.id,
       enableLiveActivity: source.enableLiveActivity,
       reminderTimeInSeconds: source.reminderTimeInSeconds,
+      customReminderMessage: source.customReminderMessage,
       enableBreaks: source.enableBreaks,
       enableStrictMode: source.enableStrictMode,
       enableAllowMode: source.enableAllowMode,

--- a/Foqos/Models/Shared.swift
+++ b/Foqos/Models/Shared.swift
@@ -25,6 +25,7 @@ enum SharedData {
 
     var enableLiveActivity: Bool
     var reminderTimeInSeconds: UInt32?
+    var customReminderMessage: String?
     var enableBreaks: Bool
     var enableStrictMode: Bool
     var enableAllowMode: Bool

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -40,6 +40,14 @@ class StrategyManager: ObservableObject {
     return activeSession?.isBreakAvailable ?? false
   }
 
+  func defaultReminderMessage(forProfile profile: BlockedProfiles?) -> String {
+    let baseMessage = "Get back to productivity"
+    guard let profile, !profile.isDeleted else {
+      return baseMessage
+    }
+    return baseMessage + " by enabling \(profile.name)"
+  }
+
   func loadActiveSession(context: ModelContext) {
     activeSession = getActiveSession(context: context)
 
@@ -479,7 +487,7 @@ class StrategyManager: ObservableObject {
     timersUtil
       .scheduleNotification(
         title: profileName + " time!",
-        message: "Get back to productivity by enabling " + profileName,
+        message: profile.customReminderMessage ?? defaultReminderMessage(forProfile: profile),
         seconds: TimeInterval(reminderTimeInSeconds)
       )
   }

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -487,7 +487,7 @@ class StrategyManager: ObservableObject {
     timersUtil
       .scheduleNotification(
         title: profileName + " time!",
-        message: profile.customReminderMessage ?? defaultReminderMessage(forProfile: profile),
+        message: profile.customReminderMessage.isEmpty ? defaultReminderMessage(forProfile: profile) : profile.customReminderMessage,
         seconds: TimeInterval(reminderTimeInSeconds)
       )
   }

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -19,7 +19,7 @@ struct BlockedProfileView: View {
   @State private var enableBreaks: Bool = false
   @State private var enableStrictMode: Bool = false
   @State private var reminderTimeInMinutes: Int = 15
-  @State private var customReminderMessage: String?
+  @State private var customReminderMessage: String
   @State private var enableAllowMode: Bool = false
   @State private var enableAllowModeDomain: Bool = false
   @State private var disableBackgroundStops: Bool = false
@@ -102,7 +102,7 @@ struct BlockedProfileView: View {
       initialValue: Int(profile?.reminderTimeInSeconds ?? 900) / 60
     )
     _customReminderMessage = State(
-      initialValue: profile?.customReminderMessage
+      initialValue: profile?.customReminderMessage ?? ""
     )
     _domains = State(
       initialValue: profile?.domains ?? []
@@ -292,10 +292,7 @@ struct BlockedProfileView: View {
               Text("Reminder message")
               TextField(
                 "Reminder message", // TextField title used for accessibility/VoiceOver
-                text: Binding(
-                  get: { customReminderMessage ?? "" }, // binding allows nil to represent default message
-                  set: { customReminderMessage = $0.isEmpty ? nil : $0 } // the question is: why not have an empty string represent default? why nil?
-                ),
+                text: $customReminderMessage,
                 prompt: Text(strategyManager.defaultReminderMessage(forProfile: profile))
               )
               .disabled(isBlocking)
@@ -306,10 +303,10 @@ struct BlockedProfileView: View {
 
               // Add a text field clear button unless the message is empty, nil or notifications are blocked
               if isReminderMessageTextFieldFocused &&
-                  !(customReminderMessage ?? "").isEmpty &&
+                  !customReminderMessage.isEmpty &&
                   !isBlocking {
                 Button {
-                  customReminderMessage = nil
+                  customReminderMessage = ""
                 } label: {
                   Image(systemName: "xmark.circle.fill")
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
Part fix to #94 allowing a custom reminder message to be set for each profile. The default reminder is restored when the custom reminder text field is cleared. Custom reminder string is stored in each profile, default text and reminder template lives in the StrategyManager.

NB: I've only done very basic testing pending design discussion (single profile, fresh install, iOS 26 and iPhone 17 Sim)

<img width="67" src="https://github.com/user-attachments/assets/301d7a21-a900-482c-a06d-4ce9ba7c7312" /><img width="67" src="https://github.com/user-attachments/assets/3b9ab07e-deec-4482-b6fc-98eaa7b5cb46" /> | <img width="67" src="https://github.com/user-attachments/assets/c2463c18-ca7d-495e-af15-3843b138a4ba" /><img width="67" src="https://github.com/user-attachments/assets/0bbc9c0b-6461-46a7-ab9e-e5b905963a6e" /><img width="67" src="https://github.com/user-attachments/assets/4685de9e-6c95-4569-85e3-f6d04c43608b" />
