### PR TITLE
Bug: Custom Reminder Message Not Disabled 

### DIFF
--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -301,6 +301,7 @@ struct BlockedProfileView: View {
                   customReminderMessage = String(newValue.prefix(178))
                 }
               }
+              .disabled(isBlocking)
             }
           }
 


### PR DESCRIPTION
Custom reminder message text field is now disabled when editing is blocked, fixes #144 .