### PR TITLE
Add multi-NFC tag whitelist support for blocking profiles

### DIFF
--- a/Foqos/Components/BlockedProfileView/BlockedProfilePhysicalUnblockSelector.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfilePhysicalUnblockSelector.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct BlockedProfilePhysicalUnblockSelector: View {
   let nfcTagId: String?
+  let nfcWhitelistCount: Int // New parameter
   let qrCodeId: String?
   var disabled: Bool = false
   var disabledText: String?
@@ -10,31 +11,35 @@ struct BlockedProfilePhysicalUnblockSelector: View {
   let onSetQRCode: () -> Void
   let onUnsetNFC: () -> Void
   let onUnsetQRCode: () -> Void
+  let onManageNFC: () -> Void // New callback
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       HStack(spacing: 12) {
         // NFC Tag Column
         PhysicalUnblockColumn(
-          title: "NFC Tag",
-          description: "Set a specific NFC tag that can only unblock this profile when active",
+          title: "NFC Tags",
+          description: "Set specific NFC tags that can unlock this profile when active",
           systemImage: "wave.3.right.circle.fill",
           id: nfcTagId,
+          whitelistCount: nfcWhitelistCount,
           disabled: disabled,
           onSet: onSetNFC,
-          onUnset: onUnsetNFC
+          onUnset: onUnsetNFC,
+          onManage: onManageNFC
         )
 
-        // QR Code Column
+        // QR Code Column (unchanged behavior)
         PhysicalUnblockColumn(
           title: "QR/Barcode Code",
-          description:
-            "Set a specific QR/Barcode code that can only unblock this profile when active",
+          description: "Set a specific QR/Barcode code that can only unblock this profile when active",
           systemImage: "qrcode.viewfinder",
           id: qrCodeId,
+          whitelistCount: 0, // QR codes don't support whitelist
           disabled: disabled,
           onSet: onSetQRCode,
-          onUnset: onUnsetQRCode
+          onUnset: onUnsetQRCode,
+          onManage: {} // Not used for QR codes
         )
       }
 
@@ -55,12 +60,14 @@ struct BlockedProfilePhysicalUnblockSelector: View {
         // Example with no IDs set
         BlockedProfilePhysicalUnblockSelector(
           nfcTagId: nil,
+          nfcWhitelistCount: 0,
           qrCodeId: nil,
           disabled: false,
           onSetNFC: { print("Set NFC") },
           onSetQRCode: { print("Set QR Code") },
           onUnsetNFC: { print("Unset NFC") },
-          onUnsetQRCode: { print("Unset QR Code") }
+          onUnsetQRCode: { print("Unset QR Code") },
+          onManageNFC: { print("Manage NFC") }
         )
       }
 
@@ -68,12 +75,14 @@ struct BlockedProfilePhysicalUnblockSelector: View {
         // Example with IDs set
         BlockedProfilePhysicalUnblockSelector(
           nfcTagId: "nfc_12345678901234567890",
+          nfcWhitelistCount: 3,
           qrCodeId: "qr_abcdefghijklmnopqrstuvwxyz",
           disabled: false,
           onSetNFC: { print("Set NFC") },
           onSetQRCode: { print("Set QR Code") },
           onUnsetNFC: { print("Unset NFC") },
-          onUnsetQRCode: { print("Unset QR Code") }
+          onUnsetQRCode: { print("Unset QR Code") },
+          onManageNFC: { print("Manage NFC") }
         )
       }
 
@@ -81,13 +90,15 @@ struct BlockedProfilePhysicalUnblockSelector: View {
         // Example disabled
         BlockedProfilePhysicalUnblockSelector(
           nfcTagId: "nfc_12345678901234567890",
+          nfcWhitelistCount: 2,
           qrCodeId: nil,
           disabled: true,
           disabledText: "Physical unblock options are locked",
           onSetNFC: { print("Set NFC") },
           onSetQRCode: { print("Set QR Code") },
           onUnsetNFC: { print("Unset NFC") },
-          onUnsetQRCode: { print("Unset QR Code") }
+          onUnsetQRCode: { print("Unset QR Code") },
+          onManageNFC: { print("Manage NFC") }
         )
       }
     }

--- a/Foqos/Components/BlockedProfileView/NFCTagManager.swift
+++ b/Foqos/Components/BlockedProfileView/NFCTagManager.swift
@@ -1,0 +1,214 @@
+import SwiftUI
+import SwiftData
+
+/**
+ Simple UI for managing multiple NFC tags per profile.
+ */
+struct NFCTagManager: View {
+    @Environment(\.modelContext) private var context
+    @Binding var profile: BlockedProfiles
+    @Binding var isPresented: Bool
+
+    @State private var isScanning = false
+    @State private var showingError = false
+    @State private var errorMessage = ""
+    @State private var editingTag: NFCTagWhitelist? = nil
+    @State private var showingRenameAlert = false
+    @State private var newTagName = ""
+
+    private let maxTags = 15
+    private let nfcScanner = NFCScannerUtil()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Button(action: startScanning) {
+                        HStack {
+                            Image(systemName: "plus.circle.fill")
+                                .foregroundStyle(.blue)
+                            Text("Add NFC Tag")
+                            Spacer()
+                            if isScanning {
+                                ProgressView()
+                                    .scaleEffect(0.8)
+                            }
+                        }
+                    }
+                    .disabled(isScanning || profile.nfcWhitelist.count >= maxTags)
+
+                    // Temporary test button for simulator
+                    Button(action: addTestTag) {
+                        HStack {
+                            Image(systemName: "wrench.and.screwdriver.fill")
+                                .foregroundStyle(.orange)
+                            Text("Add Test Tag (Simulator)")
+                        }
+                    }
+                    .disabled(profile.nfcWhitelist.count >= maxTags)
+                } header: {
+                    Text("Add New Tag")
+                } footer: {
+                    Text("Scan an NFC tag to add it to this profile. Use 'Add Test Tag' for simulator testing.")
+                }
+
+                Section {
+                    ForEach(profile.nfcWhitelist, id: \.id) { tag in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(tag.name ?? "Unnamed Tag")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                Spacer()
+                                Button("Rename") {
+                                    editingTag = tag
+                                    newTagName = tag.name ?? ""
+                                    showingRenameAlert = true
+                                }
+                                .font(.caption)
+                                .foregroundStyle(.blue)
+                            }
+                            Text("ID: \(String(tag.tagId.prefix(8)))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                    .onDelete(perform: deleteTags)
+
+                    if profile.nfcWhitelist.isEmpty {
+                        Text("No NFC tags configured.")
+                            .foregroundStyle(.secondary)
+                            .font(.subheadline)
+                    }
+                } header: {
+                    HStack {
+                        Text("NFC Tags")
+                        Spacer()
+                        Text("\(profile.nfcWhitelist.count) of \(maxTags)")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("NFC Tags")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        isPresented = false
+                    }
+                }
+            }
+        }
+        .onAppear(perform: setupNFCScanner)
+        .alert("Error", isPresented: $showingError) {
+            Button("OK") {}
+        } message: {
+            Text(errorMessage)
+        }
+        .alert("Rename Tag", isPresented: $showingRenameAlert) {
+            TextField("Tag Name", text: $newTagName)
+            Button("Cancel", role: .cancel) {}
+            Button("Save") {
+                renameTag()
+            }
+        }
+    }
+
+    private func setupNFCScanner() {
+        nfcScanner.onTagScanned = { result in
+            Task { @MainActor in
+                self.isScanning = false
+                await self.handleScannedTag(result)
+            }
+        }
+
+        nfcScanner.onError = { error in
+            Task { @MainActor in
+                self.isScanning = false
+                self.showError(error)
+            }
+        }
+    }
+
+    private func startScanning() {
+        guard nfcScanner.isNFCAvailable() else {
+            showError("NFC is not available on this device.")
+            return
+        }
+
+        isScanning = true
+        nfcScanner.scanForWhitelist(profileName: profile.name)
+    }
+
+    // Temporary test method for simulator
+    private func addTestTag() {
+        Task { @MainActor in
+            let timestamp = Int(Date().timeIntervalSince1970)
+            let testTagId = "test_tag_\(timestamp)"
+            let testResult = NFCResult(id: testTagId, url: nil, DateScanned: Date())
+            await handleScannedTag(testResult)
+        }
+    }
+
+    @MainActor
+    private func handleScannedTag(_ result: NFCResult) async {
+        let tagId = result.url ?? result.id
+
+        // Check if tag already exists
+        if profile.nfcWhitelist.contains(where: { $0.tagId == tagId }) {
+            showError("This NFC tag is already in the list.")
+            return
+        }
+
+        // Check limit
+        if profile.nfcWhitelist.count >= maxTags {
+            showError("Maximum of \(maxTags) tags allowed.")
+            return
+        }
+
+        // Add new tag
+        let newTag = NFCTagWhitelist(tagId: tagId, tagUrl: result.url, name: "NFC Tag")
+        newTag.profile = profile
+        context.insert(newTag)
+
+        do {
+            try context.save()
+        } catch {
+            showError("Failed to save tag: \(error.localizedDescription)")
+        }
+    }
+
+    private func deleteTags(at offsets: IndexSet) {
+        for index in offsets {
+            let tag = profile.nfcWhitelist[index]
+            context.delete(tag)
+        }
+
+        do {
+            try context.save()
+        } catch {
+            showError("Failed to delete tag: \(error.localizedDescription)")
+        }
+    }
+
+    private func renameTag() {
+        guard let tag = editingTag else { return }
+
+        tag.name = newTagName.isEmpty ? "NFC Tag" : newTagName
+
+        do {
+            try context.save()
+        } catch {
+            showError("Failed to rename tag: \(error.localizedDescription)")
+        }
+
+        editingTag = nil
+        newTagName = ""
+    }
+
+    private func showError(_ message: String) {
+        errorMessage = message
+        showingError = true
+    }
+}

--- a/Foqos/Models/NFCTagWhitelist.swift
+++ b/Foqos/Models/NFCTagWhitelist.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftData
+
+/**
+ A simple model for storing multiple NFC tags per profile.
+ */
+@Model
+class NFCTagWhitelist {
+    @Attribute(.unique) var id: UUID
+    var tagId: String
+    var tagUrl: String?
+    var name: String?
+    var dateAdded: Date
+
+    @Relationship(inverse: \BlockedProfiles.nfcWhitelist) var profile: BlockedProfiles?
+
+    init(tagId: String, tagUrl: String? = nil, name: String? = nil, dateAdded: Date = Date()) {
+        self.id = UUID()
+        self.tagId = tagId
+        self.tagUrl = tagUrl
+        self.name = name
+        self.dateAdded = dateAdded
+    }
+}

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -61,6 +61,9 @@ struct BlockedProfileView: View {
   // Sheet for physical unblock
   @State private var showingPhysicalUnblockView = false
 
+  // Sheet for NFC tag management
+  @State private var showingNFCTagManager = false
+
   // Alert for cloning
   @State private var showingClonePrompt = false
   @State private var cloneName: String = ""
@@ -273,18 +276,33 @@ struct BlockedProfileView: View {
         Section("Strict Unlocks") {
           BlockedProfilePhysicalUnblockSelector(
             nfcTagId: physicalUnblockNFCTagId,
+            nfcWhitelistCount: profile?.nfcWhitelist.count ?? 0,
             qrCodeId: physicalUnblockQRCodeId,
             disabled: isBlocking,
+            disabledText: isBlocking ? "Cannot modify settings during active session" : nil,
             onSetNFC: {
-              physicalReader.readNFCTag(
-                onSuccess: { physicalUnblockNFCTagId = $0 },
-              )
+              showingNFCTagManager = true
             },
             onSetQRCode: {
               showingPhysicalUnblockView = true
             },
-            onUnsetNFC: { physicalUnblockNFCTagId = nil },
-            onUnsetQRCode: { physicalUnblockQRCodeId = nil }
+            onUnsetNFC: {
+              // Clear both legacy and whitelist
+              physicalUnblockNFCTagId = nil
+              if let profile = profile {
+                for tag in profile.nfcWhitelist {
+                  try? BlockedProfiles.removeNFCTag(
+                    from: profile,
+                    context: modelContext,
+                    tagId: tag.tagId
+                  )
+                }
+              }
+            },
+            onUnsetQRCode: { physicalUnblockQRCodeId = nil },
+            onManageNFC: {
+              showingNFCTagManager = true
+            }
           )
         }
 
@@ -417,9 +435,6 @@ struct BlockedProfileView: View {
           }
         }
 
-        if #available(iOS 26.0, *) {
-          ToolbarSpacer(.flexible, placement: .topBarTrailing)
-        }
 
         if !isBlocking {
           ToolbarItem(placement: .topBarTrailing) {
@@ -464,6 +479,14 @@ struct BlockedProfileView: View {
       .sheet(isPresented: $showingInsights) {
         if let validProfile = profile {
           ProfileInsightsView(profile: validProfile)
+        }
+      }
+      .sheet(isPresented: $showingNFCTagManager) {
+        if let validProfile = profile {
+          NFCTagManager(
+            profile: .constant(validProfile),
+            isPresented: $showingNFCTagManager
+          )
         }
       }
       .background(


### PR DESCRIPTION
## Summary
  Implements multi-NFC tag whitelist support for blocking profiles, allowing users to configure
  multiple NFC tags instead of being limited to just one.
  Closes #160

  ## Changes
  - Add NFCTagWhitelist model for storing multiple NFC tags per profile
  - Create NFCTagManager UI for adding, renaming, and deleting NFC tags
  - Update NFCBlockingStrategy to support whitelist-based unlock validation
  - Add migration support for existing single NFC tag configurations
  - Implement 15-tag limit with duplicate prevention and error handling
  - Add simulator test functionality for development without physical tags

  ## Testing
  - [x] Tested adding/removing multiple NFC tags
  - [x] Verified 15-tag limit enforcement
  - [x] Tested rename and delete functionality
  - [x] Verified data persistence across app sessions

  ## Screenshots
  # Profile Details
  Before adding any Strict Unlocks
<img width="384" height="302" alt="Screenshot 2025-12-04 at 2 02 42 PM" src="https://github.com/user-attachments/assets/59df922d-7a0e-4147-9513-1709cff7bff8" />
<br>
   NFC Tags Manager allows the user to add multiple tags (added test mode for using simulator)
<img width="382" height="576" alt="Screenshot 2025-12-04 at 2 03 26 PM" src="https://github.com/user-attachments/assets/1f5710d9-570b-4dee-b203-be6aa2b2084e" />
<br>
  After adding any Strict Unlocks
<img width="381" height="328" alt="Screenshot 2025-12-04 at 2 03 30 PM" src="https://github.com/user-attachments/assets/81c6cacb-37d0-4006-a1fb-e37dc08d9112" />
