### PR TITLE
Improve language for reset date text

### DIFF
--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -351,16 +351,11 @@ class StrategyManager: ObservableObject {
     let lastResetDate = Date(
       timeIntervalSinceReferenceDate: lastEmergencyUnblocksResetDateTimestamp)
     let calendar = Calendar.current
-    if let weekAdjusted = calendar.date(
+    return calendar.date(
       byAdding: .weekOfYear,
       value: emergencyUnblocksResetPeriodInWeeks,
       to: lastResetDate
-    ) {
-        // Add one extra day to display the day the reset has occurred
-        return calendar.date(byAdding: .day, value: 1, to: weekAdjusted)
-    }
-      
-    return nil
+    )
   }
 
   func getResetPeriodInWeeks() -> Int {

--- a/Foqos/Views/EmergencyView.swift
+++ b/Foqos/Views/EmergencyView.swift
@@ -38,10 +38,20 @@ struct EmergencyView: View {
             Image(systemName: "clock.arrow.circlepath")
               .font(.caption)
               .foregroundColor(.secondary)
-            if let nextResetDate = strategyManager.getNextResetDate() {
-              Text("Resets \(nextResetDate, format: .dateTime.month().day())")
-                .font(.caption)
-            }
+              
+              Group {
+                if let nextResetDate = strategyManager.getNextResetDate() {
+                  let timeUntilReset = nextResetDate.timeIntervalSinceNow
+                  if timeUntilReset <= 24 * 60 * 60 { // Less than 24 hours
+                    let hoursRemaining = max(1, Int(ceil(timeUntilReset / 3600)))
+                    Text("Resets in \(hoursRemaining)h")
+                      .font(.caption)
+                  } else {
+                    Text("Resets \(nextResetDate, format: .dateTime.month().day())")
+                      .font(.caption)
+                  }
+                }
+              }
           }
           .padding(.vertical, 6)
 


### PR DESCRIPTION
Fixes: https://github.com/awaseem/foqos/issues/194

## Summary 

Add an extra day to `getNextResetDate` so that it properly displays the day that the reset is actually applied. This should help the user to understand clearly the day they can use emergency breaks again.

## TODOs

- [x] Ensure the reset is actually taking place on the reset day (so the new date is correctly showing when it is available again)
- [x] Change `Remaining X` time from only dates to change to a countdown when less than 24 hours remain