### PR TITLE
Customize Foqos app for DO product

### DIFF
--- a/Foqos/Components/BlockedProfileView/BlockedProfilePhysicalUnblockSelector.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfilePhysicalUnblockSelector.swift
@@ -13,30 +13,16 @@ struct BlockedProfilePhysicalUnblockSelector: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      HStack(spacing: 12) {
-        // NFC Tag Column
-        PhysicalUnblockColumn(
-          title: "NFC Tag",
-          description: "Set a specific NFC tag that can only unblock this profile when active",
-          systemImage: "wave.3.right.circle.fill",
-          id: nfcTagId,
-          disabled: disabled,
-          onSet: onSetNFC,
-          onUnset: onUnsetNFC
-        )
-
-        // QR Code Column
-        PhysicalUnblockColumn(
-          title: "QR/Barcode Code",
-          description:
-            "Set a specific QR/Barcode code that can only unblock this profile when active",
-          systemImage: "qrcode.viewfinder",
-          id: qrCodeId,
-          disabled: disabled,
-          onSet: onSetQRCode,
-          onUnset: onUnsetQRCode
-        )
-      }
+      // DO Card Column (NFC-based unlock)
+      PhysicalUnblockColumn(
+        title: "DO Card",
+        description: "Set a specific DO Card that can only unlock this profile when active",
+        systemImage: "wave.3.right.circle.fill",
+        id: nfcTagId,
+        disabled: disabled,
+        onSet: onSetNFC,
+        onUnset: onUnsetNFC
+      )
 
       if let disabledText = disabledText, disabled {
         Text(disabledText)
@@ -52,42 +38,42 @@ struct BlockedProfilePhysicalUnblockSelector: View {
   NavigationStack {
     Form {
       Section {
-        // Example with no IDs set
+        // Example with no ID set
         BlockedProfilePhysicalUnblockSelector(
           nfcTagId: nil,
           qrCodeId: nil,
           disabled: false,
-          onSetNFC: { print("Set NFC") },
-          onSetQRCode: { print("Set QR Code") },
-          onUnsetNFC: { print("Unset NFC") },
-          onUnsetQRCode: { print("Unset QR Code") }
+          onSetNFC: { print("Set DO Card") },
+          onSetQRCode: { },
+          onUnsetNFC: { print("Unset DO Card") },
+          onUnsetQRCode: { }
         )
       }
 
       Section {
-        // Example with IDs set
+        // Example with ID set
         BlockedProfilePhysicalUnblockSelector(
-          nfcTagId: "nfc_12345678901234567890",
-          qrCodeId: "qr_abcdefghijklmnopqrstuvwxyz",
+          nfcTagId: "do_card_12345678901234567890",
+          qrCodeId: nil,
           disabled: false,
-          onSetNFC: { print("Set NFC") },
-          onSetQRCode: { print("Set QR Code") },
-          onUnsetNFC: { print("Unset NFC") },
-          onUnsetQRCode: { print("Unset QR Code") }
+          onSetNFC: { print("Set DO Card") },
+          onSetQRCode: { },
+          onUnsetNFC: { print("Unset DO Card") },
+          onUnsetQRCode: { }
         )
       }
 
       Section {
         // Example disabled
         BlockedProfilePhysicalUnblockSelector(
-          nfcTagId: "nfc_12345678901234567890",
+          nfcTagId: "do_card_12345678901234567890",
           qrCodeId: nil,
           disabled: true,
-          disabledText: "Physical unblock options are locked",
-          onSetNFC: { print("Set NFC") },
-          onSetQRCode: { print("Set QR Code") },
-          onUnsetNFC: { print("Unset NFC") },
-          onUnsetQRCode: { print("Unset QR Code") }
+          disabledText: "Physical unlock options are locked",
+          onSetNFC: { print("Set DO Card") },
+          onSetQRCode: { },
+          onUnsetNFC: { print("Unset DO Card") },
+          onUnsetQRCode: { }
         )
       }
     }

--- a/Foqos/Components/BlockedProfileView/PhysicalUnblockColumn.swift
+++ b/Foqos/Components/BlockedProfileView/PhysicalUnblockColumn.swift
@@ -110,79 +110,41 @@ struct PhysicalUnblockColumn: View {
   NavigationStack {
     Form {
       Section("Not Set") {
-        HStack(spacing: 12) {
-          PhysicalUnblockColumn(
-            title: "NFC Tag",
-            description: "Set a specific NFC tag that can only unblock this profile when active",
-            systemImage: "wave.3.right",
-            id: nil,
-            disabled: false,
-            onSet: { print("Set NFC") },
-            onUnset: { print("Unset NFC") }
-          )
-
-          PhysicalUnblockColumn(
-            title: "QR Code",
-            description:
-              "Set a specific QR/Barcode code that can only unblock this profile when active",
-            systemImage: "qrcode",
-            id: nil,
-            disabled: false,
-            onSet: { print("Set QR Code") },
-            onUnset: { print("Unset QR Code") }
-          )
-        }
+        PhysicalUnblockColumn(
+          title: "DO Card",
+          description: "Set a specific DO Card that can only unlock this profile when active",
+          systemImage: "wave.3.right",
+          id: nil,
+          disabled: false,
+          onSet: { print("Set DO Card") },
+          onUnset: { print("Unset DO Card") }
+        )
       }
 
       Section("Set") {
-        HStack(spacing: 12) {
-          PhysicalUnblockColumn(
-            title: "NFC Tag",
-            description: "Set a specific NFC tag that can only unblock this profile when active",
-            systemImage: "wave.3.right",
-            id: "nfc_12345678901234567890",
-            disabled: false,
-            onSet: { print("Set NFC") },
-            onUnset: { print("Unset NFC") }
-          )
-
-          PhysicalUnblockColumn(
-            title: "QR Code",
-            description:
-              "Set a specific QR/Barcode code that can only unblock this profile when active",
-            systemImage: "qrcode",
-            id: "qr_abcdefghijklmnopqrstuvwxyz",
-            disabled: false,
-            onSet: { print("Set QR Code") },
-            onUnset: { print("Unset QR Code") }
-          )
-        }
+        PhysicalUnblockColumn(
+          title: "DO Card",
+          description: "Set a specific DO Card that can only unlock this profile when active",
+          systemImage: "wave.3.right",
+          id: "do_card_12345678901234567890",
+          disabled: false,
+          onSet: { print("Set DO Card") },
+          onUnset: { print("Unset DO Card") }
+        )
       }
 
       Section("Disabled") {
-        HStack(spacing: 12) {
-          PhysicalUnblockColumn(
-            title: "NFC Tag",
-            description: "Set a specific NFC tag that can only unblock this profile when active",
-            systemImage: "wave.3.right",
-            id: "nfc_12345678901234567890",
-            disabled: true,
-            onSet: { print("Set NFC") },
-            onUnset: { print("Unset NFC") }
-          )
-
-          PhysicalUnblockColumn(
-            title: "QR Code",
-            description: "Set a specific QR code that can only unblock this profile when active",
-            systemImage: "qrcode",
-            id: nil,
-            disabled: true,
-            onSet: { print("Set QR Code") },
-            onUnset: { print("Unset QR Code") }
-          )
-        }
+        PhysicalUnblockColumn(
+          title: "DO Card",
+          description: "Set a specific DO Card that can only unlock this profile when active",
+          systemImage: "wave.3.right",
+          id: "do_card_12345678901234567890",
+          disabled: true,
+          onSet: { print("Set DO Card") },
+          onUnset: { print("Unset DO Card") }
+        )
       }
     }
-    .navigationTitle("Physical Unblock Columns")
+    .navigationTitle("Physical Unlock Settings")
   }
 }

--- a/Foqos/Components/Common/AppTitle.swift
+++ b/Foqos/Components/Common/AppTitle.swift
@@ -7,7 +7,7 @@ struct AppTitle: View {
   let horizontalPadding: CGFloat
 
   init(
-    _ title: String = "Foqos",
+    _ title: String = "DO",
     font: Font = .largeTitle,
     fontWeight: Font.Weight = .bold,
     horizontalPadding: CGFloat = 16
@@ -31,7 +31,7 @@ struct AppTitle: View {
   VStack(spacing: 24) {
     AppTitle()
 
-    AppTitle("Foqos", font: .title, fontWeight: .semibold)
+    AppTitle("DO", font: .title, fontWeight: .semibold)
 
     AppTitle("Custom Title", font: .title2, fontWeight: .medium, horizontalPadding: 24)
   }

--- a/Foqos/Components/Dashboard/Welcome.swift
+++ b/Foqos/Components/Dashboard/Welcome.swift
@@ -9,7 +9,7 @@ struct Welcome: View {
       VStack(alignment: .leading, spacing: 12) {
         // Top row with category and icon
         HStack {
-          Text("Physically block distracting apps ")
+          Text("Block distracting apps with DO Card")
             .font(.subheadline)
             .fontWeight(.medium)
             .foregroundColor(.primary)
@@ -30,13 +30,13 @@ struct Welcome: View {
           .frame(height: 10)
 
         // Title and subtitle
-        Text("Welcome to Foqos")
+        Text("Welcome to DO")
           .font(.title)
           .fontWeight(.bold)
           .foregroundColor(.primary)
 
         Text(
-          "Tap here to get started on your first profile. You can use NFC Tags, QR codes or even Barcode codes."
+          "Tap here to get started on your first profile. Use your DO Card to lock and unlock apps."
         )
         .font(.subheadline)
         .foregroundColor(.secondary)

--- a/Foqos/Components/Intro/FeaturesIntroScreen.swift
+++ b/Foqos/Components/Intro/FeaturesIntroScreen.swift
@@ -7,21 +7,15 @@ struct FeaturesIntroScreen: View {
   let features = [
     Feature(
       imageName: "NFCLogo",
-      title: "NFC Tags",
+      title: "DO Card Lock/Unlock",
       description:
-        "Tap your phone on an NFC tag to instantly start or stop a focus session. You can buy them on Amazon for a few dollars."
-    ),
-    Feature(
-      imageName: "QRCodeLogo",
-      title: "QR Codes",
-      description:
-        "Scan a QR code to control your focus sessions. Place codes around your space to create intentional focus triggers. You can even use barcodes."
+        "Tap your phone on your DO Card to instantly lock or unlock apps. Same card to start, same card to stop."
     ),
     Feature(
       imageName: "ScheduleIcon",
-      title: "Smart Schedules",
+      title: "Timed Sessions",
       description:
-        "Set up automatic focus sessions based on your routine. Create schedules for work, study, personal time, and more."
+        "Set a timer duration to lock apps. Unlock early by tapping your DO Card, or let them auto-unlock when time expires."
     ),
   ]
 

--- a/Foqos/Components/Intro/PermissionsIntroScreen.swift
+++ b/Foqos/Components/Intro/PermissionsIntroScreen.swift
@@ -68,23 +68,13 @@ struct PermissionsIntroScreen: View {
 
       // Message text
       VStack(spacing: 16) {
-        (Text("Foqos is 100% open source, ")
-          + Text("read the code yourself")
-          .foregroundColor(.accentColor)
-          + Text(
-            " if you're skeptical. We don't care who you are, we just want you to live with focus and intention."
-          ))
+        Text("DO uses Screen Time to block distracting apps. Your data stays on your device.")
           .font(.system(size: 16, weight: .medium))
           .foregroundColor(.secondary)
           .multilineTextAlignment(.center)
           .lineSpacing(4)
-          .onTapGesture {
-            if let url = URL(string: "https://github.com/awaseem/foqos") {
-              UIApplication.shared.open(url)
-            }
-          }
 
-        Text("No account required. No subscription fees. No tracking. No BS.")
+        Text("No account required. No subscription fees. No tracking.")
           .font(.system(size: 16, weight: .medium))
           .foregroundColor(.secondary)
           .multilineTextAlignment(.center)

--- a/Foqos/Components/Intro/WelcomeIntroScreen.swift
+++ b/Foqos/Components/Intro/WelcomeIntroScreen.swift
@@ -12,13 +12,13 @@ struct WelcomeIntroScreen: View {
     VStack(spacing: 0) {
       // Heading
       VStack(spacing: 8) {
-        Text("Welcome to Foqos")
+        Text("Welcome to DO")
           .font(.system(size: 34, weight: .bold))
           .foregroundColor(.primary)
           .opacity(showContent ? 1 : 0)
           .offset(y: showContent ? 0 : -20)
 
-        Text("Live your best life with focus and intention.")
+        Text("Block distractions. Stay focused. Get things done.")
           .font(.system(size: 16))
           .foregroundColor(.secondary)
           .opacity(showContent ? 1 : 0)
@@ -38,31 +38,13 @@ struct WelcomeIntroScreen: View {
           .rotationEffect(.degrees(orbitRotation))
           .opacity(showIcons ? 1 : 0)
 
-        // Orbiting Barcode Icon (90 degrees)
-        Image("BarcodeIcon")
-          .resizable()
-          .scaledToFit()
-          .frame(width: 50, height: 50)
-          .offset(x: ORBIT_OFFSET)  // Orbit radius
-          .rotationEffect(.degrees(orbitRotation + 90))
-          .opacity(showIcons ? 1 : 0)
-
-        // Orbiting QR Code Logo (180 degrees)
-        Image("QRCodeLogo")
-          .resizable()
-          .scaledToFit()
-          .frame(width: 50, height: 50)
-          .offset(x: ORBIT_OFFSET)  // Orbit radius
-          .rotationEffect(.degrees(orbitRotation + 180))
-          .opacity(showIcons ? 1 : 0)
-
-        // Orbiting Schedule Icon (270 degrees)
+        // Orbiting Schedule Icon (180 degrees)
         Image("ScheduleIcon")
           .resizable()
           .scaledToFit()
           .frame(width: 50, height: 50)
           .offset(x: ORBIT_OFFSET)  // Orbit radius
-          .rotationEffect(.degrees(orbitRotation + 270))
+          .rotationEffect(.degrees(orbitRotation + 180))
           .opacity(showIcons ? 1 : 0)
 
         // 3D Logo (center/sun)
@@ -80,7 +62,7 @@ struct WelcomeIntroScreen: View {
       // Message text
       VStack(spacing: 12) {
         Text(
-          "No need to waste hundreds on gimmicky plastic bricks and overpriced metal cards."
+          "Use your DO Card to lock and unlock apps. Stay focused with timed sessions."
         )
         .font(.system(size: 18, weight: .medium))
         .foregroundColor(.secondary)

--- a/Foqos/Intents/CheckProfileStatusIntent.swift
+++ b/Foqos/Intents/CheckProfileStatusIntent.swift
@@ -12,9 +12,9 @@ struct CheckProfileStatusIntent: AppIntent {
 
   @Parameter(title: "Profile") var profile: BlockedProfileEntity
 
-  static var title: LocalizedStringResource = "Foqos Profile Status"
+  static var title: LocalizedStringResource = "DO Profile Status"
   static var description = IntentDescription(
-    "Check if a Foqos profile is currently active and return the status as a boolean value.")
+    "Check if a DO profile is currently active and return the status as a boolean value.")
 
   @MainActor
   func perform() async throws -> some IntentResult & ReturnsValue<Bool> & ProvidesDialog {

--- a/Foqos/Intents/CheckSessionActiveIntent.swift
+++ b/Foqos/Intents/CheckSessionActiveIntent.swift
@@ -10,9 +10,9 @@ struct CheckSessionActiveIntent: AppIntent {
     return modelContainer.mainContext
   }
 
-  static var title: LocalizedStringResource = "Check if Foqos Session is Active"
+  static var title: LocalizedStringResource = "Check if DO Session is Active"
   static var description = IntentDescription(
-    "Check if any Foqos blocking session is currently active and return true or false. Useful for automation and shortcuts."
+    "Check if any DO blocking session is currently active and return true or false. Useful for automation and shortcuts."
   )
 
   static var openAppWhenRun: Bool = false
@@ -29,8 +29,8 @@ struct CheckSessionActiveIntent: AppIntent {
 
     let dialogMessage =
       isActive
-      ? "A Foqos session is currently active."
-      : "No Foqos session is active."
+      ? "A DO session is currently active."
+      : "No DO session is active."
 
     return .result(
       value: isActive,

--- a/Foqos/Intents/StartProfileIntent.swift
+++ b/Foqos/Intents/StartProfileIntent.swift
@@ -14,10 +14,10 @@ struct StartProfileIntent: AppIntent {
 
   @Parameter(title: "Duration minutes (Optional)") var durationInMinutes: Int?
 
-  static var title: LocalizedStringResource = "Start Foqos Profile"
+  static var title: LocalizedStringResource = "Start DO Profile"
 
   static var description = IntentDescription(
-    "Start a Foqos blocking profile. Optionally specify a timer duration in minutes (15-1440)."
+    "Start a DO blocking profile. Optionally specify a timer duration in minutes (15-1440)."
   )
 
   @MainActor

--- a/Foqos/Intents/StopProfileIntent.swift
+++ b/Foqos/Intents/StopProfileIntent.swift
@@ -12,7 +12,7 @@ struct StopProfileIntent: AppIntent {
 
   @Parameter(title: "Profile") var profile: BlockedProfileEntity
 
-  static var title: LocalizedStringResource = "Stop Foqos Profile"
+  static var title: LocalizedStringResource = "Stop DO Profile"
 
   @MainActor
   func perform() async throws -> some IntentResult {

--- a/Foqos/Models/Strategies/NFCBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCBlockingStrategy.swift
@@ -4,11 +4,11 @@ import SwiftUI
 class NFCBlockingStrategy: BlockingStrategy {
   static var id: String = "NFCBlockingStrategy"
 
-  var name: String = "NFC Tags"
+  var name: String = "DO Card Lock/Unlock"
   var description: String =
-    "Block and unblock profiles by using the exact same NFC tag"
+    "Tap your DO Card to lock apps. Tap again to unlock."
   var iconType: String = "wave.3.right.circle.fill"
-  var color: Color = .yellow
+  var color: Color = Color(hex: "#FF6B35")
 
   var hidden: Bool = false
 
@@ -58,14 +58,14 @@ class NFCBlockingStrategy: BlockingStrategy {
         // Physical unblock tag is set - only this specific tag can unblock
         if physicalUnblockNFCTagId != tag {
           self.onErrorMessage?(
-            "This NFC tag is not allowed to unblock this profile. Physical unblock setting is on for this profile"
+            "This DO Card is not allowed to unlock this profile. Physical unlock setting is on for this profile."
           )
           return
         }
       } else if !session.forceStarted && session.tag != tag {
         // No physical unblock tag - must use original session tag (unless force started)
         self.onErrorMessage?(
-          "You must scan the original tag to stop focus"
+          "You must tap the same DO Card to unlock"
         )
         return
       }

--- a/Foqos/Models/Strategies/NFCTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCTimerBlockingStrategy.swift
@@ -4,10 +4,10 @@ import SwiftUI
 class NFCTimerBlockingStrategy: BlockingStrategy {
   static var id: String = "NFCTimerBlockingStrategy"
 
-  var name: String = "NFC + Timer"
-  var description: String = "Block for a certain amount of minutes, unblock by using any NFC tag"
+  var name: String = "Timed Lock with Early Unlock"
+  var description: String = "Set a timer duration. Unlock early with DO Card, or auto-unlock when timer expires."
   var iconType: String = "alarm.waves.left.and.right"
-  var color: Color = .mint
+  var color: Color = Color(hex: "#FF6B35").opacity(0.8)
 
   var hidden: Bool = false
 
@@ -63,7 +63,7 @@ class NFCTimerBlockingStrategy: BlockingStrategy {
         physicalUnblockNFCTagId != tag
       {
         self.onErrorMessage?(
-          "This NFC tag is not allowed to unblock this profile. Physical unblock setting is on for this profile"
+          "This DO Card is not allowed to unlock this profile. Physical unlock setting is on for this profile."
         )
         return
       }

--- a/Foqos/Utils/NFCScannerUtil.swift
+++ b/Foqos/Utils/NFCScannerUtil.swift
@@ -26,7 +26,7 @@ class NFCScannerUtil: NSObject {
       delegate: self,
       queue: nil
     )
-    nfcSession?.alertMessage = "Hold your iPhone near an NFC tag to trigger " + profileName
+    nfcSession?.alertMessage = "Hold your iPhone near your DO Card to trigger " + profileName
     nfcSession?.begin()
   }
 
@@ -47,7 +47,7 @@ class NFCScannerUtil: NSObject {
     let ndefSession = NFCNDEFReaderSession(
       delegate: self, queue: nil, invalidateAfterFirstRead: false)
     ndefSession.alertMessage =
-      "Hold your iPhone near an NFC tag to write the profile."
+      "Hold your iPhone near your DO Card to write the profile."
     ndefSession.begin()
   }
 }
@@ -254,7 +254,7 @@ extension NFCScannerUtil: NFCNDEFReaderSessionDelegate {
         session.invalidate(
           errorMessage: "Write failed: \(error.localizedDescription)")
       } else {
-        session.alertMessage = "Successfully wrote URL to tag"
+        session.alertMessage = "Successfully wrote profile to DO Card"
         session.invalidate()
       }
     }

--- a/Foqos/Utils/NFCWriter.swift
+++ b/Foqos/Utils/NFCWriter.swift
@@ -45,7 +45,7 @@ class NFCWriter: NSObject, ObservableObject {
       delegate: self,
       queue: nil
     )
-    tagSession?.alertMessage = "Hold your iPhone near an NFC tag to write the profile."
+    tagSession?.alertMessage = "Hold your iPhone near your DO Card to write the profile."
     tagSession?.begin()
 
     isScanning = true
@@ -191,7 +191,7 @@ extension NFCWriter: NFCTagReaderSessionDelegate {
         session.invalidate(
           errorMessage: "Write failed. Please try again.")
       } else {
-        session.alertMessage = "✓ Successfully wrote profile to tag"
+        session.alertMessage = "✓ Successfully wrote profile to DO Card"
         DispatchQueue.main.async {
           self.isScanning = false
         }

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -5,16 +5,22 @@ import WidgetKit
 class StrategyManager: ObservableObject {
   static var shared = StrategyManager()
 
+  // DO App: Only two locking methods - NFC Card and NFC + Timer
   static let availableStrategies: [BlockingStrategy] = [
-    ManualBlockingStrategy(),
     NFCBlockingStrategy(),
-    NFCManualBlockingStrategy(),
     NFCTimerBlockingStrategy(),
-    QRCodeBlockingStrategy(),
-    QRManualBlockingStrategy(),
-    QRTimerBlockingStrategy(),
+  ]
+
+  // Internal strategies for background operations (not shown in UI)
+  private static let internalStrategies: [BlockingStrategy] = [
+    ManualBlockingStrategy(),
     ShortcutTimerBlockingStrategy(),
   ]
+
+  // All strategies for lookup purposes
+  private static var allStrategies: [BlockingStrategy] {
+    return availableStrategies + internalStrategies
+  }
 
   @Published var elapsedTime: TimeInterval = 0
   @Published var timer: Timer?
@@ -392,7 +398,7 @@ class StrategyManager: ObservableObject {
   }
 
   static func getStrategyFromId(id: String) -> BlockingStrategy {
-    if let strategy = availableStrategies.first(
+    if let strategy = allStrategies.first(
       where: {
         $0.getIdentifier() == id
       })

--- a/Foqos/Utils/ThemeManager.swift
+++ b/Foqos/Utils/ThemeManager.swift
@@ -3,26 +3,18 @@ import SwiftUI
 class ThemeManager: ObservableObject {
   static let shared = ThemeManager()
 
-  // Single source of truth for all theme colors
+  // DO App fixed color scheme - Orange accent on black background
+  static let primaryColor = Color(hex: "#FF6B35")  // Vibrant orange
+  static let backgroundColor = Color(hex: "#000000")  // Pure black
+  static let textColor = Color.white
+  static let secondaryTextColor = Color(hex: "#AAAAAA")
+
+  // Single source of truth for all theme colors (keeping for compatibility, but using fixed orange)
   static let availableColors: [(name: String, color: Color)] = [
-    ("Grimace Purple", Color(hex: "#894fa3")),
-    ("Ocean Blue", Color(hex: "#007aff")),
-    ("Mint Fresh", Color(hex: "#00c6bf")),
-    ("Lime Zest", Color(hex: "#7fd800")),
-    ("Sunset Coral", Color(hex: "#ff5966")),
-    ("Hot Pink", Color(hex: "#ff2da5")),
-    ("Tangerine", Color(hex: "#ff9300")),
-    ("Lavender Dream", Color(hex: "#ba8eff")),
-    ("San Diego Merlot", Color(hex: "#7a1e3a")),
-    ("Forest Green", Color(hex: "#0b6e4f")),
-    ("Miami Vice", Color(hex: "#ff6ec7")),
-    ("Electric Lemonade", Color(hex: "#ccff00")),
-    ("Neon Grape", Color(hex: "#b026ff")),
-    ("Slate Stone", Color(hex: "#708090")),
-    ("Warm Sandstone", Color(hex: "#c4a77d")),
+    ("DO Orange", Color(hex: "#FF6B35")),
   ]
 
-  private static let defaultColorName = "Grimace Purple"
+  private static let defaultColorName = "DO Orange"
 
   @AppStorage(
     "foqosThemeColorName", store: UserDefaults(suiteName: "group.dev.ambitionsoftware.foqos"))
@@ -37,8 +29,8 @@ class ThemeManager: ObservableObject {
   }
 
   var themeColor: Color {
-    Self.availableColors.first(where: { $0.name == themeColorName })?.color
-      ?? Self.availableColors.first!.color
+    // Always return the DO orange color
+    return ThemeManager.primaryColor
   }
 
   func setTheme(named name: String) {

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -270,7 +270,7 @@ struct BlockedProfileView: View {
           CustomToggle(
             title: "Strict",
             description:
-              "Block deleting apps from your phone, stops you from deleting Foqos to access apps",
+              "Block deleting apps from your phone, stops you from deleting DO to access apps",
             isOn: $enableStrictMode,
             isDisabled: isBlocking
           )
@@ -278,7 +278,7 @@ struct BlockedProfileView: View {
           CustomToggle(
             title: "Disable Background Stops",
             description:
-              "Disable the ability to stop a profile from the background, this includes shortcuts and scanning links from NFC tags or QR codes.",
+              "Disable the ability to stop a profile from the background, this includes shortcuts and scanning links from DO Card.",
             isOn: $disableBackgroundStops,
             isDisabled: isBlocking
           )
@@ -396,13 +396,7 @@ struct BlockedProfileView: View {
                 Button {
                   writeProfile()
                 } label: {
-                  Label("Write to NFC Tag", systemImage: "tag")
-                }
-
-                Button {
-                  showingGeneratedQRCode = true
-                } label: {
-                  Label("Generate QR code", systemImage: "qrcode")
+                  Label("Write to DO Card", systemImage: "tag")
                 }
 
                 Button {
@@ -559,9 +553,9 @@ struct BlockedProfileView: View {
           )
         case .overwriteNFCWarning:
           return Alert(
-            title: Text("Warning: NFC Tag Already Set"),
+            title: Text("Warning: DO Card Already Set"),
             message: Text(
-              "Writing to this NFC tag will overwrite its current data. If this is the tag you previously set for unblocking, it will no longer match and you won't be able to unblock your profile. Continue?"
+              "Writing to this DO Card will overwrite its current data. If this is the card you previously set for unlocking, it will no longer match and you won't be able to unlock your profile. Continue?"
             ),
             primaryButton: .cancel(),
             secondaryButton: .default(Text("Continue")) {

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -30,9 +30,6 @@ struct HomeView: View {
   // Stats sheet
   @State private var profileToShowStats: BlockedProfiles? = nil
 
-  // Donation View
-  @State private var showDonationView = false
-
   // Settings View
   @State private var showSettingsView = false
 
@@ -41,9 +38,6 @@ struct HomeView: View {
 
   // Navigate to profile
   @State private var navigateToProfileId: UUID? = nil
-
-  // Debug mode
-  @State private var showingDebugMode = false
 
   // Activity sessions
   @Query(sort: \BlockedProfileSession.startTime, order: .reverse) private
@@ -87,18 +81,11 @@ struct HomeView: View {
         HStack(alignment: .center) {
           AppTitle()
           Spacer()
-          HStack(spacing: 8) {
-            RoundedButton(
-              "Support",
-              action: {
-                showDonationView = true
-              }, iconName: "heart.fill")
-            RoundedButton(
-              "",
-              action: {
-                showSettingsView = true
-              }, iconName: "gear")
-          }
+          RoundedButton(
+            "",
+            action: {
+              showSettingsView = true
+            }, iconName: "gear")
         }
         .padding(.trailing, 16)
         .padding(.top, 16)
@@ -156,14 +143,6 @@ struct HomeView: View {
           )
         }
 
-        VersionFooter(
-          profileIsActive: isBlocking,
-          tapProfileDebugHandler: {
-            showingDebugMode = true
-          }
-        )
-        .frame(maxWidth: .infinity)
-        .padding(.top, 15)
       }
     }
     .refreshable {
@@ -243,18 +222,12 @@ struct HomeView: View {
       )
       .presentationDetents([.medium])
     }
-    .sheet(isPresented: $showDonationView) {
-      SupportView()
-    }
     .sheet(isPresented: $showSettingsView) {
       SettingsView()
     }
     .sheet(isPresented: $showEmergencyView) {
       EmergencyView()
         .presentationDetents([.height(350)])
-    }
-    .sheet(isPresented: $showingDebugMode) {
-      DebugView()
     }
     .alert(alertTitle, isPresented: $showingAlert) {
       Button("OK", role: .cancel) { dismissAlert() }
@@ -302,9 +275,10 @@ struct HomeView: View {
 #Preview {
   HomeView()
     .environmentObject(RequestAuthorizer())
-    .environmentObject(TipManager())
     .environmentObject(NavigationManager())
     .environmentObject(StrategyManager())
+    .environmentObject(ThemeManager.shared)
+    .environmentObject(RatingManager())
     .defaultAppStorage(UserDefaults(suiteName: "preview")!)
     .onAppear {
       UserDefaults(suiteName: "preview")!.set(

--- a/Foqos/Views/SettingsView.swift
+++ b/Foqos/Views/SettingsView.swift
@@ -2,8 +2,6 @@ import FamilyControls
 import SwiftData
 import SwiftUI
 
-let AMZN_STORE_LINK = "https://amzn.to/4fbMuTM"
-
 struct SettingsView: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(\.modelContext) private var context
@@ -21,38 +19,6 @@ struct SettingsView: View {
   var body: some View {
     NavigationStack {
       Form {
-        Section("Theme") {
-          HStack {
-            Image(systemName: "paintpalette.fill")
-              .foregroundStyle(themeManager.themeColor)
-              .font(.title3)
-
-            VStack(alignment: .leading, spacing: 2) {
-              Text("Appearance")
-                .font(.headline)
-              Text("Customize the look of your app")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-          .padding(.vertical, 8)
-
-          Picker("Theme Color", selection: $themeManager.selectedColorName) {
-            ForEach(ThemeManager.availableColors, id: \.name) { colorOption in
-              HStack {
-                Circle()
-                  .fill(colorOption.color)
-                  .frame(width: 20, height: 20)
-                Text(colorOption.name)
-              }
-              .tag(colorOption.name)
-            }
-          }
-          .onChange(of: themeManager.selectedColorName) { _, _ in
-            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-          }
-        }
-
         Section("About") {
           HStack {
             Text("Version")
@@ -73,38 +39,6 @@ struct SettingsView: View {
               Text(requestAuthorizer.getAuthorizationStatus() == .approved ? "Authorized" : "Not Authorized")
                 .foregroundStyle(.secondary)
                 .font(.subheadline)
-            }
-          }
-
-          HStack {
-            Text("Made in")
-              .foregroundStyle(.primary)
-            Spacer()
-            Text("Calgary AB 🇨🇦")
-              .foregroundStyle(.secondary)
-          }
-        }
-
-        Section("Buy NFC Tags") {
-          Link(destination: URL(string: AMZN_STORE_LINK)!) {
-            HStack {
-              Text("Amazon")
-                .foregroundColor(.primary)
-              Spacer()
-              Image(systemName: "arrow.up.right.square")
-                .foregroundColor(.secondary)
-            }
-          }
-        }
-
-        Section("Help") {
-          Link(destination: URL(string: "https://www.foqos.app/blocking-native-apps.html")!) {
-            HStack {
-              Text("Blocking Native Apps")
-                .foregroundColor(.primary)
-              Spacer()
-              Image(systemName: "arrow.up.right.square")
-                .foregroundColor(.secondary)
             }
           }
         }

--- a/Foqos/foqosApp.swift
+++ b/Foqos/foqosApp.swift
@@ -1,8 +1,8 @@
 //
-//  foqosApp.swift
-//  foqos
+//  doApp.swift
+//  DO
 //
-//  Created by Ali Waseem on 2024-10-06.
+//  App to block distracting apps using DO Card (NFC)
 //
 
 import AppIntents
@@ -22,9 +22,8 @@ private let container: ModelContainer = {
 }()
 
 @main
-struct foqosApp: App {
+struct doApp: App {
   @StateObject private var requestAuthorizer = RequestAuthorizer()
-  @StateObject private var donationManager = TipManager()
   @StateObject private var navigationManager = NavigationManager()
   @StateObject private var nfcWriter = NFCWriter()
   @StateObject private var ratingManager = RatingManager()
@@ -62,7 +61,6 @@ struct foqosApp: App {
 
         }
         .environmentObject(requestAuthorizer)
-        .environmentObject(donationManager)
         .environmentObject(startegyManager)
         .environmentObject(navigationManager)
         .environmentObject(nfcWriter)


### PR DESCRIPTION
- Update color theme: black background (#000000) with orange accent (#FF6B35)
- Rebrand all "Foqos" references to "DO" throughout the app
- Simplify locking methods to two options only:
  - DO Card Lock/Unlock (NFC-based)
  - Timed Lock with Early Unlock (NFC + Timer)
- Remove debug section and functionality from HomeView
- Remove support/donation section from HomeView
- Update Settings view: remove theme picker and external links
- Update intro screens with DO branding and NFC-focused messaging
- Update NFC utilities to use "DO Card" terminology
- Update all Siri shortcut intents with DO branding
- Remove QR code options from physical unlock selector
