### PR TITLE
[Feature] StopActiveSessionIntent

### DIFF
--- a/Foqos/Intents/StopActiveSessionIntent.swift
+++ b/Foqos/Intents/StopActiveSessionIntent.swift
@@ -12,7 +12,7 @@ struct StopActiveSessionIntent: AppIntent {
 
   static var title: LocalizedStringResource = "Stop Active Foqos Session"
   static var description = IntentDescription(
-    "Stops the currently active Foqos session, if any. Useful for quickly ending a blocking session from Shortcuts or Siri."
+    "Attempts to stop any currently active Foqos session."
   )
 
   static var openAppWhenRun: Bool = false


### PR DESCRIPTION
closes #254 

## Summary
Add a new shortcut step `StopActiveSessionIntent` which stops any active profile.

<kbd><img width="414" height="278" alt="Screenshot 2026-02-01 at 3 22 43 PM" src="https://github.com/user-attachments/assets/c06bd191-87b9-40ea-a3b0-39cec2da4c8a" /></kbd>

## Old Behavior
- `Start Foqos Profile` step did nothing when a session for a different profile was already active
	-	terminal would log (when attempting to start `Sleep` profile): `session is already active for profile: Work Focus, not starting a new one`
- `Stop Foqos Profile` step results in error popup when attempting to stop a profile that has `disableBackgroundStops` enabled
	-	popup message: `profile: "<name>" has disable background stops enabled, not stopping it`

## New Behavior
- `Stop Active Foqos Session` step finds and stops any active profile.
- `Stop Active Foqos Session` step returns `false` and will display dialog if attempting to stop a profile with `disableBackgroundStops` enabled. No popup is displayed in the app.

## Shortcut Return Values
- `true`:
	- no profile is active
		- `OR`
	- a profile is active `AND` it does not have `disableBackgroundStops` enabled `AND` it is stopped successfully
- `false`:
	- a profile is active `AND` it has `disableBackgroundStops` enabled

<kbd><img width="300" height="172" alt="Screenshot 2026-02-01 at 3 23 24 PM" src="https://github.com/user-attachments/assets/17465eb9-5932-45eb-8f28-b893640b4a4e" /></kbd>
<kbd><img width="300" height="211" alt="Screenshot 2026-02-01 at 3 23 09 PM" src="https://github.com/user-attachments/assets/9fcfd3e3-9a55-4316-ba5d-3f4b2cd1500b" /></kbd>
<kbd><img width="300" height="178" alt="Screenshot 2026-02-01 at 3 22 58 PM" src="https://github.com/user-attachments/assets/8b37584c-b3b9-42d8-ac9b-cc2504601d4c" /></kbd>

## Use Case
This new step allows for hands free toggling of profiles via Shortcuts. Example:
1. Scan NFC tag for `Work` profile, automation runs, step triggered to start `Work`
2. Scan NFC tag for `Sleep` profile, automation runs, all active sessions stopped, `Sleep` starts. No need to re-scan `Work` profile.
> [!NOTE]
> For true toggling, the shortcut steps should first see if the target profile is active and then `if/else` to stop active sessions or start/stop the target profile.

This also allows for a shortcut/NFC tag to be used solely for stopping whatever profile is running, if people have a reason for that. No need to specify which profile to stop.

## Testing
Ran through use case demonstration on iPhone 17 in simulator. Highlighting behavior without and with the new step:

[Imgur video link](https://imgur.com/MDXg5RJ)