### PR TITLE
Fix typo in break notification message

### DIFF
--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -618,7 +618,7 @@ class StrategyManager: ObservableObject {
     if breakNotificationTimeInSeconds > 0 {
       timersUtil.scheduleNotification(
         title: "Break almost over!",
-        message: "Hope you enjoyed your break, starting " + profileName + " in a 1 minute.",
+        message: "Hope you enjoyed your break, starting " + profileName + " in 1 minute.",
         seconds: TimeInterval(breakNotificationTimeInSeconds)
       )
     }


### PR DESCRIPTION
Noticed this typo in the notification when a break is coming to an end.