### PR TITLE
Add TapBlok as an Android alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@
 - **🌐 Website Blocking**: Block distracting websites in addition to apps
 - **🔄 Live Activities**: Real-time status on your Lock Screen
 
-## 🤖 Android Alternative
+## 🤖 Android Alternatives
 
-Looking for similar functionality on Android? Check out **[Switchly](https://switchly.saltyy.at/#features)** — a physical blocker for Android that helps you stay focused by putting your distracting apps behind NFC tags.
+Looking for similar functionality on Android? Check out these open-source physical blockers:
+
+- **[Switchly](https://switchly.saltyy.at/#features)** — a physical blocker for Android that helps you stay focused by putting your distracting apps behind NFC tags.
+- **[TapBlok](https://github.com/cajdata/TapBlok)** — an open-source Android app that blocks distracting apps behind NFC tags or QR codes, built with Kotlin and Jetpack Compose.
 
 ## 📋 Requirements
 


### PR DESCRIPTION
Hey! You mentioned on Reddit you'd be happy to include an Android alternative in the README. TapBlok is an open-source Android app with a very similar philosophy to Foqos — it puts distracting apps behind NFC tags or QR codes to create intentional friction.

**[TapBlok on GitHub](https://github.com/cajdata/TapBlok)**

This PR updates the Android Alternatives section to list TapBlok alongside Switchly. Let me know if you'd prefer different wording!