### PR TITLE
fix: debug view remains visible when profile is active

### DIFF
--- a/Foqos/Views/SettingsView.swift
+++ b/Foqos/Views/SettingsView.swift
@@ -123,27 +123,30 @@ struct SettingsView: View {
           }
         }
 
-        if !strategyManager.isBlocking {
-          Section("Help") {
-            Link(destination: URL(string: "https://www.foqos.app/blocking-native-apps.html")!) {
-              HStack {
-                Text("Blocking Native Apps")
-                  .foregroundColor(.primary)
-                Spacer()
-                Image(systemName: "arrow.up.right.square")
-                  .foregroundColor(.secondary)
-              }
-            }
-
+        Section("Help") {
+          Link(destination: URL(string: "https://www.foqos.app/blocking-native-apps.html")!) {
             HStack {
-              Text("Debug Mode")
+              Text("Blocking Native Apps")
                 .foregroundColor(.primary)
               Spacer()
-              Image(systemName: "chevron.right")
+              Image(systemName: "arrow.up.right.square")
                 .foregroundColor(.secondary)
-                .font(.caption)
             }
+          }
 
+          HStack {
+            Text("Debug Mode")
+              .foregroundColor(.primary)
+            Spacer()
+            Image(systemName: "chevron.right")
+              .foregroundColor(.secondary)
+              .font(.caption)
+          }
+          .onTapGesture {
+            showDebugView = true
+          }
+
+          if !strategyManager.isBlocking {
             Button {
               showResetBlockingStateAlert = true
             } label: {

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ When reporting issues, please include:
 - Expected vs actual behavior
 - Screenshots if applicable
 - **Debug output** (needed for diagnosing issues):
-  1. Open Settings → Developer → Debug Mode
+  1. Open Settings → Help → Debug Mode
   2. Tap the copy button on the right-hand side
   3. Paste the output in your issue report
 


### PR DESCRIPTION
- Move condition from entire Help section to just Reset Blocking State button
- Add missing onTapGesture for Debug Mode option
- Update README path from Developer to Help section

big whoops on my part 