### PR TITLE
Add Pause Mode blocking strategy

### DIFF
--- a/Foqos/Models/Shared.swift
+++ b/Foqos/Models/Shared.swift
@@ -11,6 +11,8 @@ enum SharedData {
     case profileSnapshots
     case activeScheduleSession
     case completedScheduleSessions
+    case pauseModeActiveProfileId
+    case pauseUnlockedApps
   }
 
   // MARK: – Serializable snapshot of a profile (no sessions)
@@ -151,6 +153,55 @@ enum SharedData {
 
   static func flushActiveSession() {
     activeSharedSession = nil
+  }
+
+  // MARK: – Pause mode state (used by ShieldConfigurationExtension & ShieldActionExtension)
+
+  /// The profile ID currently running a PauseBlockingStrategy session.
+  /// Set when the session starts, cleared when it stops.
+  static var pauseModeActiveProfileId: String? {
+    get { suite.string(forKey: Key.pauseModeActiveProfileId.rawValue) }
+    set { suite.set(newValue, forKey: Key.pauseModeActiveProfileId.rawValue) }
+  }
+
+  /// Bundle IDs of apps that have already been unlocked in the current session.
+  static var pauseUnlockedApps: Set<String> {
+    get { Set(suite.stringArray(forKey: Key.pauseUnlockedApps.rawValue) ?? []) }
+    set { suite.set(Array(newValue), forKey: Key.pauseUnlockedApps.rawValue) }
+  }
+
+  static func clearUnlockedApps() {
+    pauseUnlockedApps = []
+  }
+
+  // MARK: Per-app pause timers (individual UserDefaults keys — cheap r/w, no JSON overhead)
+
+  private static func pauseTimerKey(for bundleId: String) -> String {
+    "pauseTimer_\(bundleId)"
+  }
+
+  static func pauseTimer(for bundleId: String) -> Date? {
+    guard let t = suite.object(forKey: pauseTimerKey(for: bundleId)) as? Double else { return nil }
+    return Date(timeIntervalSince1970: t)
+  }
+
+  static func startPauseTimer(for bundleId: String) {
+    suite.set(Date().timeIntervalSince1970, forKey: pauseTimerKey(for: bundleId))
+  }
+
+  static func clearPauseTimer(for bundleId: String) {
+    suite.removeObject(forKey: pauseTimerKey(for: bundleId))
+  }
+
+  static func clearAllPauseTimers() {
+    suite.dictionaryRepresentation().keys
+      .filter { $0.hasPrefix("pauseTimer_") }
+      .forEach { suite.removeObject(forKey: $0) }
+  }
+
+  static func elapsedPauseTime(for bundleId: String) -> TimeInterval {
+    guard let t = suite.object(forKey: pauseTimerKey(for: bundleId)) as? Double else { return 0 }
+    return Date().timeIntervalSince1970 - t
   }
 
   static func getCompletedSessionsForSchedular() -> [SessionSnapshot] {

--- a/Foqos/Models/Strategies/Data/StrategyPauseDelayData.swift
+++ b/Foqos/Models/Strategies/Data/StrategyPauseDelayData.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct StrategyPauseDelayData: Codable {
+  var delaySeconds: Int = 5
+
+  static func toStrategyPauseDelayData(from data: Data) -> StrategyPauseDelayData {
+    do {
+      return try JSONDecoder().decode(StrategyPauseDelayData.self, from: data)
+    } catch {
+      return StrategyPauseDelayData(delaySeconds: 5)
+    }
+  }
+
+  static func toData(from data: StrategyPauseDelayData) -> Data? {
+    return try? JSONEncoder().encode(data)
+  }
+}

--- a/Foqos/Models/Strategies/PauseBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/PauseBlockingStrategy.swift
@@ -1,0 +1,71 @@
+import SwiftData
+import SwiftUI
+
+class PauseBlockingStrategy: BlockingStrategy {
+  static let id: String = "PauseBlockingStrategy"
+
+  var name: String = "Pause Mode"
+  var description: String = "Shows a countdown before temporarily unlocking each app you tap."
+  var iconType: String = "hourglass"
+  var color: Color = .purple
+
+  var hasPauseMode: Bool = true
+  var startsManually: Bool = true
+
+  var hidden: Bool = false
+
+  var onSessionCreation: ((SessionStatus) -> Void)?
+  var onErrorMessage: ((String) -> Void)?
+
+  private let appBlocker: AppBlockerUtil = AppBlockerUtil()
+
+  func getIdentifier() -> String {
+    return PauseBlockingStrategy.id
+  }
+
+  func startBlocking(
+    context: ModelContext,
+    profile: BlockedProfiles,
+    forceStart: Bool?
+  ) -> (any View)? {
+    // Activate restrictions first
+    self.appBlocker
+      .activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
+
+    let activeSession =
+      BlockedProfileSession
+      .createSession(
+        in: context,
+        withTag: PauseBlockingStrategy.id,
+        withProfile: profile,
+        forceStart: forceStart ?? false
+      )
+
+    // Signal to shield extensions that pause mode is active for this profile
+    SharedData.pauseModeActiveProfileId = profile.id.uuidString
+
+    self.onSessionCreation?(.started(activeSession))
+
+    return nil
+  }
+
+  func stopBlocking(
+    context: ModelContext,
+    session: BlockedProfileSession
+  ) -> (any View)? {
+    // Clear SharedData FIRST so extensions stop reading stale state
+    SharedData.pauseModeActiveProfileId = nil
+    SharedData.clearAllPauseTimers()
+    SharedData.clearUnlockedApps()
+
+    // Restore full restrictions (re-block all apps in profile)
+    self.appBlocker.deactivateRestrictions()
+
+    session.endSession()
+    try? context.save()
+
+    self.onSessionCreation?(.ended(session.blockedProfile))
+
+    return nil
+  }
+}

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -6,6 +6,7 @@ class StrategyManager: ObservableObject {
   static var shared = StrategyManager()
 
   static let availableStrategies: [BlockingStrategy] = [
+    PauseBlockingStrategy(),
     ManualBlockingStrategy(),
     NFCBlockingStrategy(),
     NFCManualBlockingStrategy(),

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -77,6 +77,8 @@ struct BlockedProfileView: View {
   // Sheet for insights modal
   @State private var showingInsights = false
 
+  @State private var pauseDelaySeconds: Int = 5
+
   @State private var selectedActivity = FamilyActivitySelection()
   @State private var selectedStrategy: BlockingStrategy? = nil
 
@@ -159,6 +161,11 @@ struct BlockedProfileView: View {
           StrategyManager
           .getStrategyFromId(id: profileStrategyId)
       )
+      // Load pause delay setting when editing a Pause Mode profile
+      if profileStrategyId == PauseBlockingStrategy.id, let data = profile?.strategyData {
+        _pauseDelaySeconds = State(
+          initialValue: StrategyPauseDelayData.toStrategyPauseDelayData(from: data).delaySeconds)
+      }
     } else {
       _selectedStrategy = State(initialValue: NFCBlockingStrategy())
     }
@@ -302,6 +309,24 @@ struct BlockedProfileView: View {
               Text("30 minutes").tag(30)
             }
             .disabled(isBlocking)
+          }
+        }
+
+        if selectedStrategy?.getIdentifier() == PauseBlockingStrategy.id {
+          Section {
+            Picker("Delay Before Opening", selection: $pauseDelaySeconds) {
+              Text("5 seconds").tag(5)
+              Text("10 seconds").tag(10)
+              Text("30 seconds").tag(30)
+              Text("60 seconds").tag(60)
+            }
+            .disabled(isBlocking)
+          } header: {
+            Text("Pause Mode")
+          } footer: {
+            Text(
+              "When you tap a blocked app, you'll need to wait this many seconds before the app unlocks."
+            )
           }
         }
 
@@ -628,6 +653,15 @@ struct BlockedProfileView: View {
       let reminderTimeSeconds: UInt32? =
         enableReminder ? UInt32(reminderTimeInMinutes * 60) : nil
 
+      // Encode strategy-specific data for strategies that require it
+      let strategyDataToSave: Data? = {
+        if selectedStrategy?.getIdentifier() == PauseBlockingStrategy.id {
+          return StrategyPauseDelayData.toData(
+            from: StrategyPauseDelayData(delaySeconds: pauseDelaySeconds))
+        }
+        return nil
+      }()
+
       if let existingProfile = profile {
         // Update existing profile
         let updatedProfile = try BlockedProfiles.updateProfile(
@@ -636,6 +670,7 @@ struct BlockedProfileView: View {
           name: name,
           selection: selectedActivity,
           blockingStrategyId: selectedStrategy?.getIdentifier(),
+          strategyData: strategyDataToSave,
           enableLiveActivity: enableLiveActivity,
           reminderTime: reminderTimeSeconds,
           customReminderMessage: customReminderMessage,
@@ -662,6 +697,7 @@ struct BlockedProfileView: View {
           selection: selectedActivity,
           blockingStrategyId: selectedStrategy?
             .getIdentifier() ?? NFCBlockingStrategy.id,
+          strategyData: strategyDataToSave,
           enableLiveActivity: enableLiveActivity,
           reminderTimeInSeconds: reminderTimeSeconds,
           customReminderMessage: customReminderMessage,

--- a/FoqosShieldAction/FoqosShieldAction.entitlements
+++ b/FoqosShieldAction/FoqosShieldAction.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.developer.family-controls</key>
+        <true/>
+        <key>com.apple.security.application-groups</key>
+        <array>
+            <string>group.dev.ambitionsoftware.foqos</string>
+        </array>
+    </dict>
+</plist>

--- a/FoqosShieldAction/Info.plist
+++ b/FoqosShieldAction/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.ManagedSettings.shield-action-service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShieldActionExtension</string>
+	</dict>
+</dict>
+</plist>

--- a/FoqosShieldAction/ShieldActionExtension.swift
+++ b/FoqosShieldAction/ShieldActionExtension.swift
@@ -1,0 +1,85 @@
+//
+//  ShieldActionExtension.swift
+//  FoqosShieldAction
+//
+//  Handles button taps on the system shield for profiles using PauseBlockingStrategy.
+//
+//  When the countdown has elapsed: removes only the tapped app from the blocked set
+//  (all other profile apps remain blocked) and opens the app via .defer.
+//
+//  When tapped too early: calls .close so the shield dismisses and the user can
+//  re-tap the app to see the updated remaining time.
+//
+
+import ManagedSettings
+
+class ShieldActionExtension: ShieldActionDelegate {
+  override func handle(
+    action: ShieldAction,
+    for application: ApplicationToken,
+    completionHandler: @escaping (ShieldActionResponse) -> Void
+  ) {
+    guard action == .primaryButtonPressed else {
+      completionHandler(.close)
+      return
+    }
+
+    // ApplicationToken.description returns the bundle identifier in practice.
+    // This must match the key used in ShieldConfigurationExtension (application.bundleIdentifier).
+    let bundleId = application.description
+
+    guard
+      let profileId = SharedData.pauseModeActiveProfileId,
+      let snapshot = SharedData.snapshot(for: profileId),
+      let data = snapshot.strategyData
+    else {
+      completionHandler(.close)
+      return
+    }
+
+    let delay = StrategyPauseDelayData.toStrategyPauseDelayData(from: data)
+    let elapsed = SharedData.elapsedPauseTime(for: bundleId)
+
+    // Grace window: 0.5s tolerance for extension timer drift.
+    // Also guard against stale timers (>120s) — ShieldConfig resets those on re-appearance.
+    guard elapsed >= Double(delay.delaySeconds) - 0.5, elapsed < 120 else {
+      // Tapped too early — dismiss shield; timer persists so re-tapping shows updated countdown.
+      completionHandler(.close)
+      return
+    }
+
+    // Countdown complete — diff the blocked set to remove only this specific app.
+    // All other apps in the profile remain blocked.
+    let store = ManagedSettingsStore(named: ManagedSettingsStore.Name("foqosAppRestrictions"))
+    var currentBlocked = store.shield.applications ?? []
+    currentBlocked.remove(application)
+    store.shield.applications = currentBlocked.isEmpty ? nil : currentBlocked
+
+    // Record unlock so ShieldConfig shows the normal shield if this app is tapped again
+    var unlocked = SharedData.pauseUnlockedApps
+    unlocked.insert(bundleId)
+    SharedData.pauseUnlockedApps = unlocked
+
+    // Clean up this app's pause timer
+    SharedData.clearPauseTimer(for: bundleId)
+
+    // Open the app
+    completionHandler(.defer)
+  }
+
+  override func handle(
+    action: ShieldAction,
+    for webDomain: WebDomainToken,
+    completionHandler: @escaping (ShieldActionResponse) -> Void
+  ) {
+    completionHandler(.close)
+  }
+
+  override func handle(
+    action: ShieldAction,
+    for category: ActivityCategoryToken,
+    completionHandler: @escaping (ShieldActionResponse) -> Void
+  ) {
+    completionHandler(.close)
+  }
+}

--- a/FoqosShieldConfig/ShieldConfigurationExtension.swift
+++ b/FoqosShieldConfig/ShieldConfigurationExtension.swift
@@ -15,6 +15,9 @@ import UIKit
 // Make sure that your class name matches the NSExtensionPrincipalClass in your Info.plist.
 class ShieldConfigurationExtension: ShieldConfigurationDataSource {
   override func configuration(shielding application: Application) -> ShieldConfiguration {
+    if let pauseShield = pauseModeConfiguration(for: application) {
+      return pauseShield
+    }
     return createCustomShieldConfiguration(
       for: .app, title: application.localizedDisplayName ?? "App")
   }
@@ -22,6 +25,9 @@ class ShieldConfigurationExtension: ShieldConfigurationDataSource {
   override func configuration(shielding application: Application, in category: ActivityCategory)
     -> ShieldConfiguration
   {
+    if let pauseShield = pauseModeConfiguration(for: application) {
+      return pauseShield
+    }
     return createCustomShieldConfiguration(
       for: .app, title: application.localizedDisplayName ?? "App")
   }
@@ -35,6 +41,68 @@ class ShieldConfigurationExtension: ShieldConfigurationDataSource {
   {
     return createCustomShieldConfiguration(for: .website, title: webDomain.domain ?? "Website")
   }
+
+  // MARK: – Pause Mode Shield
+
+  /// Returns a pause-mode `ShieldConfiguration` if the active session uses `PauseBlockingStrategy`,
+  /// or `nil` if the normal blocking shield should be shown instead.
+  private func pauseModeConfiguration(for application: Application) -> ShieldConfiguration? {
+    guard let profileId = SharedData.pauseModeActiveProfileId else { return nil }
+
+    // bundleIdentifier is the stable, unique key per app.
+    // If nil (rare edge case), fall through to the normal shield.
+    guard let bundleId = application.bundleIdentifier else { return nil }
+
+    let brandColor = UIColor(ThemeManager.shared.themeColor)
+    let appName = application.localizedDisplayName ?? "App"
+
+    // Already unlocked this session — ManagedSettings was updated by ShieldAction,
+    // but show the normal shield as a defensive fallback if it appears again.
+    if SharedData.pauseUnlockedApps.contains(bundleId) {
+      return nil
+    }
+
+    // Read configured delay from the profile's strategyData
+    let delaySeconds: Int = {
+      guard let snap = SharedData.snapshot(for: profileId),
+        let data = snap.strategyData
+      else { return 5 }
+      return StrategyPauseDelayData.toStrategyPauseDelayData(from: data).delaySeconds
+    }()
+
+    // Start per-app timer on first appearance
+    if SharedData.pauseTimer(for: bundleId) == nil {
+      SharedData.startPauseTimer(for: bundleId)
+    }
+
+    let elapsed = SharedData.elapsedPauseTime(for: bundleId)
+    // Use ceil so we never show "Open (in 0s)" while ShieldAction would still reject the tap
+    let remaining = max(0, Int(ceil(Double(delaySeconds) - elapsed)))
+
+    // Schedule exactly one reload for when this app's countdown expires.
+    // Multiple asyncAfters across different apps are fine — system coalesces reloadConfiguration calls.
+    if remaining > 0 {
+      DispatchQueue.main.asyncAfter(deadline: .now() + Double(remaining) + 0.1) {
+        ShieldConfigurationDataSource().reloadConfiguration()
+      }
+    }
+
+    let buttonText = remaining > 0 ? "Open (in \(remaining)s)" : "Open"
+
+    return ShieldConfiguration(
+      backgroundBlurStyle: .dark,
+      backgroundColor: brandColor,
+      icon: makeEmojiIcon("⏳", size: 96),
+      title: ShieldConfiguration.Label(text: "Why am I checking?", color: .white),
+      subtitle: ShieldConfiguration.Label(
+        text: appName, color: UIColor.white.withAlphaComponent(0.88)),
+      primaryButtonLabel: ShieldConfiguration.Label(text: buttonText, color: .black),
+      primaryButtonBackgroundColor: .white,
+      secondaryButtonLabel: nil
+    )
+  }
+
+  // MARK: – Standard Blocking Shield
 
   private func createCustomShieldConfiguration(for type: BlockedContentType, title: String)
     -> ShieldConfiguration

--- a/foqos.xcodeproj/project.pbxproj
+++ b/foqos.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		80FF388E2D80DB540032BC5E /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80C6CAFA2D4301B3008680F4 /* WidgetKit.framework */; };
 		80FF388F2D80DB540032BC5E /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80C6CAFC2D4301B3008680F4 /* SwiftUI.framework */; };
 		80FF389C2D80DB560032BC5E /* FoqosWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 80FF388D2D80DB540032BC5E /* FoqosWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		C8D73DC42F7C155D0028E76A /* ManagedSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 808A3C4B2E4ACD18002A7812 /* ManagedSettings.framework */; };
+		C8D73DCC2F7C155D0028E76A /* FoqosShieldAction.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = C8D73DC32F7C155C0028E76A /* FoqosShieldAction.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +57,13 @@
 			remoteGlobalIDString = 80FF388C2D80DB540032BC5E;
 			remoteInfo = FoqosWidgetExtension;
 		};
+		C8D73DCA2F7C155D0028E76A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 801B208D2CB363A10073E9E2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C8D73DC22F7C155C0028E76A;
+			remoteInfo = FoqosShieldAction;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -66,6 +75,7 @@
 			files = (
 				808A3C562E4ACD18002A7812 /* FoqosShieldConfig.appex in Embed Foundation Extensions */,
 				801713132DE6C78C00B77FE1 /* FoqosDeviceMonitor.appex in Embed Foundation Extensions */,
+				C8D73DCC2F7C155D0028E76A /* FoqosShieldAction.appex in Embed Foundation Extensions */,
 				80FF389C2D80DB560032BC5E /* FoqosWidgetExtension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
@@ -86,6 +96,7 @@
 		80C6CAFC2D4301B3008680F4 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		80DBF6132CB776D100EEA8A6 /* DeviceActivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DeviceActivity.framework; path = System/Library/Frameworks/DeviceActivity.framework; sourceTree = SDKROOT; };
 		80FF388D2D80DB540032BC5E /* FoqosWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FoqosWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		C8D73DC32F7C155C0028E76A /* FoqosShieldAction.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FoqosShieldAction.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -122,6 +133,8 @@
 		803899772EF736BA009988BB /* Exceptions for "Foqos" folder in "FoqosShieldConfig" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Models/Shared.swift,
+				Models/Strategies/Data/StrategyPauseDelayData.swift,
 				Utils/ThemeManager.swift,
 			);
 			target = 808A3C492E4ACD18002A7812 /* FoqosShieldConfig */;
@@ -162,6 +175,21 @@
 			);
 			target = 80FF388C2D80DB540032BC5E /* FoqosWidgetExtension */;
 		};
+		C8D73DD02F7C155D0028E76A /* Exceptions for "FoqosShieldAction" folder in "FoqosShieldAction" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = C8D73DC22F7C155C0028E76A /* FoqosShieldAction */;
+		};
+		C8D73DE12F7C20000000A001 /* Exceptions for "Foqos" folder in "FoqosShieldAction" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Models/Shared.swift,
+				Models/Strategies/Data/StrategyPauseDelayData.swift,
+			);
+			target = C8D73DC22F7C155C0028E76A /* FoqosShieldAction */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -181,6 +209,7 @@
 				801C99CE2E9C9B9D000E07CD /* Exceptions for "Foqos" folder in "FoqosWidgetExtension" target */,
 				804415942DE7E94B0000CAE4 /* Exceptions for "Foqos" folder in "FoqosDeviceMonitor" target */,
 				803899772EF736BA009988BB /* Exceptions for "Foqos" folder in "FoqosShieldConfig" target */,
+				C8D73DE12F7C20000000A001 /* Exceptions for "Foqos" folder in "FoqosShieldAction" target */,
 			);
 			path = Foqos;
 			sourceTree = "<group>";
@@ -205,6 +234,14 @@
 				80FF38A02D80DB560032BC5E /* Exceptions for "FoqosWidget" folder in "FoqosWidgetExtension" target */,
 			);
 			path = FoqosWidget;
+			sourceTree = "<group>";
+		};
+		C8D73DC52F7C155D0028E76A /* FoqosShieldAction */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				C8D73DD02F7C155D0028E76A /* Exceptions for "FoqosShieldAction" folder in "FoqosShieldAction" target */,
+			);
+			path = FoqosShieldAction;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -259,6 +296,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C8D73DC02F7C155C0028E76A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8D73DC42F7C155D0028E76A /* ManagedSettings.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -270,6 +315,7 @@
 				80FF38902D80DB540032BC5E /* FoqosWidget */,
 				8017130C2DE6C78C00B77FE1 /* FoqosDeviceMonitor */,
 				808A3C4F2E4ACD18002A7812 /* FoqosShieldConfig */,
+				C8D73DC52F7C155D0028E76A /* FoqosShieldAction */,
 				80DBF6122CB776D100EEA8A6 /* Frameworks */,
 				801B20962CB363A10073E9E2 /* Products */,
 			);
@@ -284,6 +330,7 @@
 				80FF388D2D80DB540032BC5E /* FoqosWidgetExtension.appex */,
 				8017130A2DE6C78C00B77FE1 /* FoqosDeviceMonitor.appex */,
 				808A3C4A2E4ACD18002A7812 /* FoqosShieldConfig.appex */,
+				C8D73DC32F7C155C0028E76A /* FoqosShieldAction.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -341,6 +388,7 @@
 				80FF389B2D80DB560032BC5E /* PBXTargetDependency */,
 				801713122DE6C78C00B77FE1 /* PBXTargetDependency */,
 				808A3C552E4ACD18002A7812 /* PBXTargetDependency */,
+				C8D73DCB2F7C155D0028E76A /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				801B20972CB363A10073E9E2 /* Foqos */,
@@ -440,6 +488,28 @@
 			productReference = 80FF388D2D80DB540032BC5E /* FoqosWidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		C8D73DC22F7C155C0028E76A /* FoqosShieldAction */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C8D73DCF2F7C155D0028E76A /* Build configuration list for PBXNativeTarget "FoqosShieldAction" */;
+			buildPhases = (
+				C8D73DBF2F7C155C0028E76A /* Sources */,
+				C8D73DC02F7C155C0028E76A /* Frameworks */,
+				C8D73DC12F7C155C0028E76A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C8D73DC52F7C155D0028E76A /* FoqosShieldAction */,
+			);
+			name = FoqosShieldAction;
+			packageProductDependencies = (
+			);
+			productName = FoqosShieldAction;
+			productReference = C8D73DC32F7C155C0028E76A /* FoqosShieldAction.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -447,7 +517,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1640;
+				LastSwiftUpdateCheck = 2640;
 				LastUpgradeCheck = 1610;
 				TargetAttributes = {
 					801713092DE6C78C00B77FE1 = {
@@ -469,6 +539,9 @@
 					};
 					80FF388C2D80DB540032BC5E = {
 						CreatedOnToolsVersion = 16.2;
+					};
+					C8D73DC22F7C155C0028E76A = {
+						CreatedOnToolsVersion = 26.4;
 					};
 				};
 			};
@@ -495,6 +568,7 @@
 				80FF388C2D80DB540032BC5E /* FoqosWidgetExtension */,
 				801713092DE6C78C00B77FE1 /* FoqosDeviceMonitor */,
 				808A3C492E4ACD18002A7812 /* FoqosShieldConfig */,
+				C8D73DC22F7C155C0028E76A /* FoqosShieldAction */,
 			);
 		};
 /* End PBXProject section */
@@ -536,6 +610,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		80FF388B2D80DB540032BC5E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C8D73DC12F7C155C0028E76A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -587,6 +668,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C8D73DBF2F7C155C0028E76A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -614,6 +702,11 @@
 			isa = PBXTargetDependency;
 			target = 80FF388C2D80DB540032BC5E /* FoqosWidgetExtension */;
 			targetProxy = 80FF389A2D80DB560032BC5E /* PBXContainerItemProxy */;
+		};
+		C8D73DCB2F7C155D0028E76A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C8D73DC22F7C155C0028E76A /* FoqosShieldAction */;
+			targetProxy = C8D73DCA2F7C155D0028E76A /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1109,6 +1202,69 @@
 			};
 			name = Release;
 		};
+		C8D73DCD2F7C155D0028E76A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = FoqosShieldAction/FoqosShieldAction.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = YR54789JNV;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FoqosShieldAction/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldAction;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosShieldAction;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C8D73DCE2F7C155D0028E76A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = FoqosShieldAction/FoqosShieldAction.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = YR54789JNV;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FoqosShieldAction/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldAction;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosShieldAction;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1171,6 +1327,15 @@
 			buildConfigurations = (
 				80FF389D2D80DB560032BC5E /* Debug */,
 				80FF389E2D80DB560032BC5E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C8D73DCF2F7C155D0028E76A /* Build configuration list for PBXNativeTarget "FoqosShieldAction" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C8D73DCD2F7C155D0028E76A /* Debug */,
+				C8D73DCE2F7C155D0028E76A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;


### PR DESCRIPTION
Introduces a new Pause Mode strategy inspired by ScreenZen. Instead of hard-blocking apps, a countdown shield is shown when a blocked app is tapped. Once the delay expires, only that specific app unlocks for the rest of the session — all other profile apps remain blocked.

Key implementation details:
- PauseBlockingStrategy: new strategy with hourglass icon, starts manually
- StrategyPauseDelayData: Codable config for per-profile delay (5/10/30/60s)
- ShieldConfigurationExtension: live countdown via reloadConfiguration(), per-app timers keyed by bundle ID, ceil to avoid 'Open (in 0s)' flash
- ShieldActionExtension: new Xcode target; on tap, diffs the blocked app set to remove only the tapped app, 0.5s grace window, stale timer guard 120s
- SharedData: pause mode active profile ID, per-app timer keys, unlocked apps set — all shared via App Group UserDefaults
- FoqosShieldAction entitlements: added App Group so SharedData is accessible
- BlockedProfileView: Pause Mode section with delay picker for this strategy
- StrategyManager: registers PauseBlockingStrategy as first available option


I could not test this as I don't have developer account