### PR TITLE
fix: use hardware hex ID for NFC tag matching instead of NDEF URL

### DIFF
--- a/Foqos/Models/Strategies/NFCBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCBlockingStrategy.swift
@@ -32,12 +32,11 @@ class NFCBlockingStrategy: BlockingStrategy {
     nfcScanner.onTagScanned = { tag in
       self.appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
 
-      let tag = tag.url ?? tag.id
       let activeSession =
         BlockedProfileSession
         .createSession(
           in: context,
-          withTag: tag,
+          withTag: tag.id,
           withProfile: profile,
           forceStart: forceStart ?? false
         )
@@ -54,16 +53,16 @@ class NFCBlockingStrategy: BlockingStrategy {
     session: BlockedProfileSession
   ) -> (any View)? {
     nfcScanner.onTagScanned = { tag in
-      let tag = tag.url ?? tag.id
+      let tagId = tag.id
 
       if session.blockedProfile.hasPhysicalUnblockItem(ofType: .nfc) {
-        if !session.blockedProfile.canUnblock(withCode: tag, type: .nfc) {
+        if !session.blockedProfile.canUnblock(withCode: tagId, type: .nfc) {
           self.onErrorMessage?(
             "This NFC tag is not allowed to unblock this profile. Physical unblock setting is on for this profile"
           )
           return
         }
-      } else if !session.forceStarted && session.tag != tag {
+      } else if !session.forceStarted && session.tag != tagId {
         // No physical unblock tag - must use original session tag (unless force started)
         self.onErrorMessage?(
           "You must scan the original tag to stop focus"

--- a/Foqos/Models/Strategies/NFCManualBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCManualBlockingStrategy.swift
@@ -51,10 +51,10 @@ class NFCManualBlockingStrategy: BlockingStrategy {
     session: BlockedProfileSession
   ) -> (any View)? {
     nfcScanner.onTagScanned = { tag in
-      let tag = tag.url ?? tag.id
+      let tagId = tag.id
 
       if session.blockedProfile.hasPhysicalUnblockItem(ofType: .nfc)
-        && !session.blockedProfile.canUnblock(withCode: tag, type: .nfc)
+        && !session.blockedProfile.canUnblock(withCode: tagId, type: .nfc)
       {
         self.onErrorMessage?(
           "This NFC tag is not allowed to unblock this profile. Physical unblock setting is on for this profile"

--- a/Foqos/Models/Strategies/NFCPauseTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCPauseTimerBlockingStrategy.swift
@@ -66,7 +66,7 @@ class NFCPauseTimerBlockingStrategy: BlockingStrategy {
     let isPauseActive = session.isPauseActive
 
     nfcScanner.onTagScanned = { tag in
-      let tagId = tag.url ?? tag.id
+      let tagId = tag.id
 
       // Check strict mode - if physical unblock is set, it must match
       if session.blockedProfile.hasPhysicalUnblockItem(ofType: .nfc)

--- a/Foqos/Models/Strategies/NFCTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCTimerBlockingStrategy.swift
@@ -60,10 +60,10 @@ class NFCTimerBlockingStrategy: BlockingStrategy {
     session: BlockedProfileSession
   ) -> (any View)? {
     nfcScanner.onTagScanned = { tag in
-      let tag = tag.url ?? tag.id
+      let tagId = tag.id
 
       if session.blockedProfile.hasPhysicalUnblockItem(ofType: .nfc)
-        && !session.blockedProfile.canUnblock(withCode: tag, type: .nfc)
+        && !session.blockedProfile.canUnblock(withCode: tagId, type: .nfc)
       {
         self.onErrorMessage?(
           "This NFC tag is not allowed to unblock this profile. Physical unblock setting is on for this profile"

--- a/Foqos/Utils/PhysicalReader.swift
+++ b/Foqos/Utils/PhysicalReader.swift
@@ -10,8 +10,7 @@ class PhysicalReader {
     onFailure: @escaping (String) -> Void = { _ in }
   ) {
     nfcScanner.onTagScanned = { result in
-      let tagId = result.url ?? result.id
-      onSuccess(tagId)
+      onSuccess(result.id)
     }
     nfcScanner.onError = onFailure
 


### PR DESCRIPTION
## Summary

- NFC tag identity matching used `tag.url ?? tag.id`, which prefers the NDEF URL when available. NDEF reads can silently fail on brief/weak taps, causing the resolved value to flip between a URL string and a hex ID across scans.
- This meant a tag used to start a session could fail to stop it — the stored value was a URL but the scanned value was a hex ID, producing a "this NFC isn't usable" error.
- Switched all NFC strategy files and `PhysicalReader` to always use `tag.id` (the hardware hex identifier), which is deterministic regardless of NDEF read success.

## Files changed

| File | Change |
|------|--------|
| `NFCBlockingStrategy.swift` | Start: stores `tag.id`. Stop: compares with `tag.id` |
| `NFCTimerBlockingStrategy.swift` | Stop: compares with `tag.id` |
| `NFCManualBlockingStrategy.swift` | Stop: compares with `tag.id` |
| `NFCPauseTimerBlockingStrategy.swift` | Stop: compares with `tag.id` |
| `PhysicalReader.swift` | Registers physical unblock items using `result.id` |

## Note

Users who previously registered NFC tags as physical unblock items may need to re-scan them, since old entries may have been stored as URLs rather than hex IDs.

## Test plan

- [ ] Start a blocking session with NFC tag, stop with same tag — should always work
- [ ] Quick/weak taps that previously caused NDEF read failures should no longer cause mismatch
- [ ] Physical unblock items: register an NFC tag, verify it unblocks reliably
- [ ] Verify existing sessions without physical unblock items still require the original tag