### PR TITLE
fix: restore clamped timer activity intervals

### DIFF
--- a/Foqos/Utils/DeviceActivityCenterUtil.swift
+++ b/Foqos/Utils/DeviceActivityCenterUtil.swift
@@ -211,6 +211,8 @@ class DeviceActivityCenterUtil {
   private static func getTimeIntervalStartAndEnd(from minutes: Int) -> (
     intervalStart: DateComponents, intervalEnd: DateComponents
   ) {
+    let intervalStart = DateComponents(hour: 0, minute: 0)
+
     // Get current time
     let now = Date()
     let currentComponents = Calendar.current.dateComponents([.hour, .minute], from: now)
@@ -219,11 +221,16 @@ class DeviceActivityCenterUtil {
 
     // Calculate end time by adding minutes to current time
     let totalMinutes = currentMinute + minutes
-    let endHour = currentHour + (totalMinutes / 60)
-    let endMinute = totalMinutes % 60
+    var endHour = currentHour + (totalMinutes / 60)
+    var endMinute = totalMinutes % 60
 
-    let intervalStart = DateComponents(hour: currentHour, minute: currentMinute)
-    let intervalEnd = DateComponents(hour: endHour % 24, minute: endMinute)
+    // Cap at 23:59 if it would roll over past midnight.
+    if endHour >= 24 || (endHour == 23 && endMinute >= 59) {
+      endHour = 23
+      endMinute = 59
+    }
+
+    let intervalEnd = DateComponents(hour: endHour, minute: endMinute)
     return (intervalStart: intervalStart, intervalEnd: intervalEnd)
   }
 }

--- a/Foqos/Views/DebugView.swift
+++ b/Foqos/Views/DebugView.swift
@@ -260,6 +260,10 @@ struct DebugView: View {
 
     if rawValue.hasPrefix(BreakTimerActivity.id) {
       return "Break Timer"
+    } else if rawValue.hasPrefix(PauseTimerActivity.id) {
+      return "Pause Timer"
+    } else if rawValue.hasPrefix(StrategyTimerActivity.id) {
+      return "Strategy Timer"
     } else if rawValue.hasPrefix(ScheduleTimerActivity.id) {
       return "Schedule Timer"
     } else {
@@ -277,6 +281,16 @@ struct DebugView: View {
 
     // Check if it's a break timer activity for this profile
     if rawValue.hasPrefix(BreakTimerActivity.id) {
+      return rawValue.hasSuffix(profileIdString)
+    }
+
+    // Check if it's a pause timer activity for this profile
+    if rawValue.hasPrefix(PauseTimerActivity.id) {
+      return rawValue.hasSuffix(profileIdString)
+    }
+
+    // Check if it's a strategy timer activity for this profile
+    if rawValue.hasPrefix(StrategyTimerActivity.id) {
       return rawValue.hasSuffix(profileIdString)
     }
 


### PR DESCRIPTION
## Summary
- restore pre-#335 clamped DeviceActivity intervals for one-shot timer activities
- keep interval start at 00:00 and cap same-day timer ends at 23:59
- recognize pause and strategy timer activities in debug output

## Context
This is a focused hotfix for #352. PR #335 changed one-shot timer schedules to start at the current minute and wrap end times modulo 24. Pause timers rely on DeviceActivity interval start callbacks to lift restrictions and mark pause state, and v1.33 reports show that callback path no longer reliably starts.

## Verification
- make lint (existing warnings remain in unrelated files)
- make build