### PR TITLE
Make activity heatmap thresholds configurable

### DIFF
--- a/Foqos/Components/Dashboard/BlockedSessionsHabitTracker.swift
+++ b/Foqos/Components/Dashboard/BlockedSessionsHabitTracker.swift
@@ -48,6 +48,12 @@ struct BlockedSessionsHabitTracker: View {
 
   @AppStorage("showHabitTracker") private var showHabitTracker = true
   @AppStorage("habitChartType") private var chartTypeRaw = HabitChartType.fourWeek.rawValue
+  @AppStorage("heatmapLowHourThreshold") private var heatmapLowHourThreshold =
+    HeatmapThresholds.defaultLowHours
+  @AppStorage("heatmapMediumHourThreshold") private var heatmapMediumHourThreshold =
+    HeatmapThresholds.defaultMediumHours
+  @AppStorage("heatmapHighHourThreshold") private var heatmapHighHourThreshold =
+    HeatmapThresholds.defaultHighHours
   @State private var showingConfiguration = false
 
   private var chartType: HabitChartType {
@@ -59,6 +65,24 @@ struct BlockedSessionsHabitTracker: View {
     Binding(
       get: { chartType },
       set: { chartTypeRaw = $0.rawValue }
+    )
+  }
+
+  private var heatmapThresholdsBinding: Binding<HeatmapThresholds> {
+    Binding(
+      get: {
+        HeatmapThresholds(
+          lowHours: heatmapLowHourThreshold,
+          mediumHours: heatmapMediumHourThreshold,
+          highHours: heatmapHighHourThreshold
+        ).normalized
+      },
+      set: { thresholds in
+        let normalizedThresholds = thresholds.normalized
+        heatmapLowHourThreshold = normalizedThresholds.lowHours
+        heatmapMediumHourThreshold = normalizedThresholds.mediumHours
+        heatmapHighHourThreshold = normalizedThresholds.highHours
+      }
     )
   }
 
@@ -125,6 +149,7 @@ struct BlockedSessionsHabitTracker: View {
       FourWeekHeatmapView(
         sessions: sessions,
         selectedDate: selectedDate,
+        thresholds: heatmapThresholdsBinding.wrappedValue,
         onDateSelected: handleDateSelection
       )
     case .weekly:
@@ -194,6 +219,7 @@ struct BlockedSessionsHabitTracker: View {
         ChartConfigurationSheet(
           showHabitTracker: $showHabitTracker,
           chartType: chartTypeBinding,
+          heatmapThresholds: heatmapThresholdsBinding,
           onDismiss: { showingConfiguration = false }
         )
         .presentationDetents([.medium, .large])

--- a/Foqos/Components/Dashboard/ChartConfigurationSheet.swift
+++ b/Foqos/Components/Dashboard/ChartConfigurationSheet.swift
@@ -4,7 +4,75 @@ struct ChartConfigurationSheet: View {
   @EnvironmentObject var themeManager: ThemeManager
   @Binding var showHabitTracker: Bool
   @Binding var chartType: HabitChartType
+  @Binding var heatmapThresholds: HeatmapThresholds
   let onDismiss: () -> Void
+
+  private var normalizedHeatmapThresholds: HeatmapThresholds {
+    heatmapThresholds.normalized
+  }
+
+  private var lowThresholdBinding: Binding<Double> {
+    Binding(
+      get: { normalizedHeatmapThresholds.lowHours },
+      set: {
+        heatmapThresholds = HeatmapThresholds(
+          lowHours: $0,
+          mediumHours: normalizedHeatmapThresholds.mediumHours,
+          highHours: normalizedHeatmapThresholds.highHours
+        ).normalized
+      }
+    )
+  }
+
+  private var mediumThresholdBinding: Binding<Double> {
+    Binding(
+      get: { normalizedHeatmapThresholds.mediumHours },
+      set: {
+        heatmapThresholds = HeatmapThresholds(
+          lowHours: normalizedHeatmapThresholds.lowHours,
+          mediumHours: $0,
+          highHours: normalizedHeatmapThresholds.highHours
+        ).normalized
+      }
+    )
+  }
+
+  private var highThresholdBinding: Binding<Double> {
+    Binding(
+      get: { normalizedHeatmapThresholds.highHours },
+      set: {
+        heatmapThresholds = HeatmapThresholds(
+          lowHours: normalizedHeatmapThresholds.lowHours,
+          mediumHours: normalizedHeatmapThresholds.mediumHours,
+          highHours: $0
+        ).normalized
+      }
+    )
+  }
+
+  private var lowThresholdRange: ClosedRange<Double> {
+    ClosedRange(
+      uncheckedBounds: (
+        lower: HeatmapThresholds.minimumHours,
+        upper: normalizedHeatmapThresholds.mediumHours - HeatmapThresholds.minimumGapHours
+      ))
+  }
+
+  private var mediumThresholdRange: ClosedRange<Double> {
+    ClosedRange(
+      uncheckedBounds: (
+        lower: normalizedHeatmapThresholds.lowHours + HeatmapThresholds.minimumGapHours,
+        upper: normalizedHeatmapThresholds.highHours - HeatmapThresholds.minimumGapHours
+      ))
+  }
+
+  private var highThresholdRange: ClosedRange<Double> {
+    ClosedRange(
+      uncheckedBounds: (
+        lower: normalizedHeatmapThresholds.mediumHours + HeatmapThresholds.minimumGapHours,
+        upper: HeatmapThresholds.maximumHours
+      ))
+  }
 
   var body: some View {
     NavigationStack {
@@ -63,6 +131,41 @@ struct ChartConfigurationSheet: View {
             .listRowSeparator(.hidden)
           }
         }
+
+        if chartType == .fourWeek {
+          Section {
+            thresholdSlider(
+              title: "Light activity",
+              value: lowThresholdBinding,
+              range: lowThresholdRange
+            )
+
+            thresholdSlider(
+              title: "Moderate activity",
+              value: mediumThresholdBinding,
+              range: mediumThresholdRange
+            )
+
+            thresholdSlider(
+              title: "High activity",
+              value: highThresholdBinding,
+              range: highThresholdRange
+            )
+
+            Button {
+              heatmapThresholds = .defaults
+            } label: {
+              Label("Reset to Default", systemImage: "arrow.counterclockwise")
+            }
+            .foregroundStyle(themeManager.themeColor)
+          } header: {
+            Text("Heatmap Scale")
+          } footer: {
+            Text(
+              "Adjust these when your focus sessions usually run longer than the default 1h, 3h, and 5h buckets."
+            )
+          }
+        }
       }
       .navigationTitle("Manage chart")
       .navigationBarTitleDisplayMode(.inline)
@@ -77,17 +180,42 @@ struct ChartConfigurationSheet: View {
       }
     }
   }
+
+  private func thresholdSlider(
+    title: String,
+    value: Binding<Double>,
+    range: ClosedRange<Double>
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Text(title)
+          .foregroundStyle(.primary)
+
+        Spacer()
+
+        Text(HeatmapThresholds.formattedHours(value.wrappedValue))
+          .font(.subheadline.monospacedDigit())
+          .foregroundStyle(.secondary)
+      }
+
+      Slider(value: value, in: range, step: 0.5)
+        .tint(themeManager.themeColor)
+    }
+    .padding(.vertical, 4)
+  }
 }
 
 #Preview {
   struct PreviewWrapper: View {
     @State private var showChart = true
     @State private var chartType: HabitChartType = .fourWeek
+    @State private var heatmapThresholds: HeatmapThresholds = .defaults
 
     var body: some View {
       ChartConfigurationSheet(
         showHabitTracker: $showChart,
         chartType: $chartType,
+        heatmapThresholds: $heatmapThresholds,
         onDismiss: {}
       )
       .environmentObject(ThemeManager.shared)

--- a/Foqos/Components/Dashboard/FourWeekHeatmapView.swift
+++ b/Foqos/Components/Dashboard/FourWeekHeatmapView.swift
@@ -1,17 +1,83 @@
 import FamilyControls
+import Foundation
 import SwiftUI
+
+struct HeatmapThresholds: Equatable {
+  static let defaultLowHours = 1.0
+  static let defaultMediumHours = 3.0
+  static let defaultHighHours = 5.0
+  static let minimumHours = 0.5
+  static let maximumHours = 24.0
+  static let minimumGapHours = 0.5
+
+  var lowHours: Double
+  var mediumHours: Double
+  var highHours: Double
+
+  static var defaults: HeatmapThresholds {
+    HeatmapThresholds(
+      lowHours: defaultLowHours,
+      mediumHours: defaultMediumHours,
+      highHours: defaultHighHours
+    )
+  }
+
+  var normalized: HeatmapThresholds {
+    let lowMaximum = Self.maximumHours - (Self.minimumGapHours * 2)
+    let mediumMaximum = Self.maximumHours - Self.minimumGapHours
+
+    let low = min(max(lowHours, Self.minimumHours), lowMaximum)
+    let medium = min(max(mediumHours, low + Self.minimumGapHours), mediumMaximum)
+    let high = min(max(highHours, medium + Self.minimumGapHours), Self.maximumHours)
+
+    return HeatmapThresholds(lowHours: low, mediumHours: medium, highHours: high)
+  }
+
+  var legendData: [(String, Double)] {
+    [
+      ("<\(Self.formattedHours(lowHours))", 0.3),
+      ("\(Self.formattedHours(lowHours))-\(Self.formattedHours(mediumHours))", 0.5),
+      ("\(Self.formattedHours(mediumHours))-\(Self.formattedHours(highHours))", 0.7),
+      (">\(Self.formattedHours(highHours))", 0.9),
+    ]
+  }
+
+  func opacity(for hours: Double) -> Double {
+    switch hours {
+    case 0:
+      return 0.15
+    case 0..<lowHours:
+      return 0.3
+    case lowHours..<mediumHours:
+      return 0.5
+    case mediumHours..<highHours:
+      return 0.7
+    default:
+      return 0.9
+    }
+  }
+
+  static func formattedHours(_ hours: Double) -> String {
+    if hours.rounded(.towardZero) == hours {
+      return "\(Int(hours))h"
+    }
+
+    return String(format: "%.1fh", hours)
+  }
+}
 
 struct FourWeekHeatmapView: View {
   @EnvironmentObject var themeManager: ThemeManager
 
   let sessions: [BlockedProfileSession]
   let selectedDate: Date?
+  let thresholds: HeatmapThresholds
   let onDateSelected: (Date) -> Void
 
   private let daysToShow = 28
 
   private var legendData: [(String, Double)] {
-    [("<1h", 0.3), ("1-3h", 0.5), ("3-5h", 0.7), (">5h", 0.9)]
+    thresholds.normalized.legendData
   }
 
   private var dates: [Date] {
@@ -27,18 +93,11 @@ struct FourWeekHeatmapView: View {
   }
 
   private func colorForHours(_ hours: Double) -> Color {
-    switch hours {
-    case 0:
+    if hours == 0 {
       return Color.gray.opacity(0.15)
-    case 0..<1:
-      return themeManager.themeColor.opacity(0.3)
-    case 1..<3:
-      return themeManager.themeColor.opacity(0.5)
-    case 3..<5:
-      return themeManager.themeColor.opacity(0.7)
-    default:
-      return themeManager.themeColor.opacity(0.9)
     }
+
+    return themeManager.themeColor.opacity(thresholds.normalized.opacity(for: hours))
   }
 
   private var legendView: some View {
@@ -137,6 +196,7 @@ struct FourWeekHeatmapView: View {
       FourWeekHeatmapView(
         sessions: sessions,
         selectedDate: nil,
+        thresholds: .defaults,
         onDateSelected: { _ in }
       )
       .environmentObject(ThemeManager.shared)

--- a/foqosTests/HeatmapThresholdsTests.swift
+++ b/foqosTests/HeatmapThresholdsTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+@testable import foqos
+
+final class HeatmapThresholdsTests: XCTestCase {
+  func testDefaultThresholdsMatchExistingHeatmapBuckets() {
+    let thresholds = HeatmapThresholds.defaults
+
+    XCTAssertEqual(thresholds.opacity(for: 0.25), 0.3)
+    XCTAssertEqual(thresholds.opacity(for: 1.5), 0.5)
+    XCTAssertEqual(thresholds.opacity(for: 4.0), 0.7)
+    XCTAssertEqual(thresholds.opacity(for: 6.0), 0.9)
+  }
+
+  func testNormalizationKeepsThresholdsOrderedWithMinimumGap() {
+    let thresholds = HeatmapThresholds(
+      lowHours: 8,
+      mediumHours: 3,
+      highHours: 2
+    ).normalized
+
+    XCTAssertEqual(thresholds.lowHours, 8)
+    XCTAssertEqual(thresholds.mediumHours, 8.5)
+    XCTAssertEqual(thresholds.highHours, 9)
+  }
+}


### PR DESCRIPTION
## Summary
- Add persisted hour thresholds for the 4-week activity heatmap
- Add heatmap scale sliders and reset action to the chart management sheet
- Update the heatmap legend and color buckets from the configured thresholds
- Add unit coverage for default bucket behavior and threshold normalization

## Testing
- make test

Closes #373