### PR TITLE
Allow break timers to cross midnight

### DIFF
--- a/Foqos/Utils/DeviceActivityCenterUtil.swift
+++ b/Foqos/Utils/DeviceActivityCenterUtil.swift
@@ -53,7 +53,7 @@ class DeviceActivityCenterUtil {
       // Remove any existing schedule and create a new one
       stopActivities(for: [deviceActivityName], with: center)
       try center.startMonitoring(deviceActivityName, during: deviceActivitySchedule)
-      print("Scheduled break timer activity from \(intervalStart) to \(intervalEnd) daily")
+      print("Scheduled break timer activity from \(intervalStart) to \(intervalEnd)")
     } catch {
       print("Failed to start break timer activity: \(error.localizedDescription)")
     }
@@ -208,29 +208,25 @@ class DeviceActivityCenterUtil {
     center.stopMonitoring(activities)
   }
 
-  private static func getTimeIntervalStartAndEnd(from minutes: Int) -> (
+  static func getTimeIntervalStartAndEnd(
+    from minutes: Int,
+    startingAt now: Date = Date(),
+    calendar: Calendar = .current
+  ) -> (
     intervalStart: DateComponents, intervalEnd: DateComponents
   ) {
-    let intervalStart = DateComponents(hour: 0, minute: 0)
+    let currentComponents = calendar.dateComponents([.hour, .minute], from: now)
+    let intervalStart = DateComponents(
+      hour: currentComponents.hour,
+      minute: currentComponents.minute
+    )
 
-    // Get current time
-    let now = Date()
-    let currentComponents = Calendar.current.dateComponents([.hour, .minute], from: now)
-    let currentHour = currentComponents.hour ?? 0
-    let currentMinute = currentComponents.minute ?? 0
-
-    // Calculate end time by adding minutes to current time
-    let totalMinutes = currentMinute + minutes
-    var endHour = currentHour + (totalMinutes / 60)
-    var endMinute = totalMinutes % 60
-
-    // Cap at 23:59 if it would roll over past midnight.
-    if endHour >= 24 || (endHour == 23 && endMinute >= 59) {
-      endHour = 23
-      endMinute = 59
-    }
-
-    let intervalEnd = DateComponents(hour: endHour, minute: endMinute)
+    let endDate = calendar.date(byAdding: .minute, value: minutes, to: now) ?? now
+    let endComponents = calendar.dateComponents([.hour, .minute], from: endDate)
+    let intervalEnd = DateComponents(
+      hour: endComponents.hour,
+      minute: endComponents.minute
+    )
     return (intervalStart: intervalStart, intervalEnd: intervalEnd)
   }
 }

--- a/foqosTests/DeviceActivityCenterUtilTests.swift
+++ b/foqosTests/DeviceActivityCenterUtilTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+@testable import foqos
+
+final class DeviceActivityCenterUtilTests: XCTestCase {
+  private var calendar: Calendar!
+
+  override func setUp() {
+    super.setUp()
+    calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+  }
+
+  override func tearDown() {
+    calendar = nil
+    super.tearDown()
+  }
+
+  func testTimerIntervalCanEndAfterMidnight() {
+    let result = DeviceActivityCenterUtil.getTimeIntervalStartAndEnd(
+      from: 15,
+      startingAt: date(2026, 5, 26, 23, 50),
+      calendar: calendar
+    )
+
+    XCTAssertEqual(result.intervalStart.hour, 23)
+    XCTAssertEqual(result.intervalStart.minute, 50)
+    XCTAssertEqual(result.intervalEnd.hour, 0)
+    XCTAssertEqual(result.intervalEnd.minute, 5)
+  }
+
+  func testTimerIntervalStaysOnSameDayWhenDurationDoesNotCrossMidnight() {
+    let result = DeviceActivityCenterUtil.getTimeIntervalStartAndEnd(
+      from: 15,
+      startingAt: date(2026, 5, 26, 10, 20),
+      calendar: calendar
+    )
+
+    XCTAssertEqual(result.intervalStart.hour, 10)
+    XCTAssertEqual(result.intervalStart.minute, 20)
+    XCTAssertEqual(result.intervalEnd.hour, 10)
+    XCTAssertEqual(result.intervalEnd.minute, 35)
+  }
+
+  private func date(
+    _ year: Int,
+    _ month: Int,
+    _ day: Int,
+    _ hour: Int,
+    _ minute: Int
+  ) -> Date {
+    DateComponents(
+      calendar: calendar,
+      timeZone: calendar.timeZone,
+      year: year,
+      month: month,
+      day: day,
+      hour: hour,
+      minute: minute
+    ).date!
+  }
+}


### PR DESCRIPTION
## Summary
- schedule timer-based breaks from the current time instead of midnight
- allow break timer intervals to end after midnight instead of clamping to 23:59
- add unit coverage for a 15 minute break started before midnight and a same-day timer case

Closes #384.

## Tests
- `make test`
- `git diff --check`

Could not run `make lint` locally because `swift-format` is not installed in this environment.
