### PR TITLE
Add description to Stop Foqos Profile intent

### DIFF
--- a/Foqos/Intents/StopProfileIntent.swift
+++ b/Foqos/Intents/StopProfileIntent.swift
@@ -14,6 +14,10 @@ struct StopProfileIntent: AppIntent {
 
   static var title: LocalizedStringResource = "Stop Foqos Profile"
 
+  static var description = IntentDescription(
+    "Stop a Foqos blocking profile."
+  )
+
   @MainActor
   func perform() async throws -> some IntentResult {
     let strategyManager = StrategyManager.shared


### PR DESCRIPTION
## Summary

The **Stop Foqos Profile** App Intent was the only Foqos intent missing a `description`, so it showed no subtitle in the Shortcuts app while every other intent (`StartProfileIntent`, `StopActiveSessionIntent`, `CheckProfileStatusIntent`, `CheckSessionActiveIntent`) had one. This adds a description matching the existing pattern.

## Changes
- `Foqos/Intents/StopProfileIntent.swift`: add `IntentDescription("Stop a Foqos blocking profile.")`

## Testing
- `make build` (via Xcode) succeeds.