### PR TITLE
Add reusable break allowance

### DIFF
--- a/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
@@ -9,6 +9,7 @@ final class BlockedProfileDraft: ObservableObject {
   @Published var enableReminder: Bool
   @Published var enableBreaks: Bool
   @Published var breakTimeInMinutes: Int
+  @Published var allowMultipleBreaks: Bool
   @Published var enableStrictMode: Bool
   @Published var enableBlockAppInstallation: Bool
   @Published var reminderTimeInMinutes: Int
@@ -35,6 +36,7 @@ final class BlockedProfileDraft: ObservableObject {
     enableLiveActivity = profile?.enableLiveActivity ?? false
     enableBreaks = profile?.enableBreaks ?? false
     breakTimeInMinutes = profile?.breakTimeInMinutes ?? 15
+    allowMultipleBreaks = profile?.allowMultipleBreaks ?? false
     enableStrictMode = profile?.enableStrictMode ?? false
     enableBlockAppInstallation = profile?.enableBlockAppInstallation ?? false
     enableAllowMode = profile?.enableAllowMode ?? false
@@ -100,6 +102,7 @@ final class BlockedProfileDraft: ObservableObject {
         customReminderMessage: customReminderMessage,
         enableBreaks: enableTimedBreaksToSave,
         breakTimeInMinutes: breakTimeInMinutes,
+        allowMultipleBreaks: enableTimedBreaksToSave && allowMultipleBreaks,
         enableStrictMode: enableStrictMode,
         enableBlockAppInstallation: enableBlockAppInstallation,
         enableAllowMode: enableAllowMode,
@@ -127,6 +130,7 @@ final class BlockedProfileDraft: ObservableObject {
       customReminderMessage: customReminderMessage,
       enableBreaks: enableTimedBreaksToSave,
       breakTimeInMinutes: breakTimeInMinutes,
+      allowMultipleBreaks: enableTimedBreaksToSave && allowMultipleBreaks,
       enableStrictMode: enableStrictMode,
       enableBlockAppInstallation: enableBlockAppInstallation,
       enableAllowMode: enableAllowMode,
@@ -150,5 +154,6 @@ final class BlockedProfileDraft: ObservableObject {
     }
 
     enableBreaks = false
+    allowMultipleBreaks = false
   }
 }

--- a/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
@@ -282,6 +282,15 @@ struct BlockedProfileBreaksFields: View {
         ProfileFieldDivider(isVisible: showsSeparators)
 
         breakDurationPicker
+
+        ProfileFieldDivider(isVisible: showsSeparators)
+
+        CustomToggle(
+          title: "Allow Multiple Breaks",
+          description: "Use the break duration across multiple breaks in this session.",
+          isOn: $draft.allowMultipleBreaks,
+          isDisabled: disabled
+        )
       }
     } else {
       ProfileFieldNotice(

--- a/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
@@ -273,7 +273,7 @@ struct BlockedProfileBreaksFields: View {
       CustomToggle(
         title: "Allow Timed Breaks",
         description:
-          "Take a single break during your session. The break will automatically end after the selected duration.",
+          "Take a break during your session. The break will automatically end after the selected duration.",
         isOn: $draft.enableBreaks,
         isDisabled: disabled
       )
@@ -287,7 +287,7 @@ struct BlockedProfileBreaksFields: View {
 
         CustomToggle(
           title: "Allow Multiple Breaks",
-          description: "Use the break duration across multiple breaks in this session.",
+          description: "Take multiple breaks until your total break duration is used.",
           isOn: $draft.allowMultipleBreaks,
           isDisabled: disabled
         )

--- a/Foqos/Components/Debug/ProfileDebugCard.swift
+++ b/Foqos/Components/Debug/ProfileDebugCard.swift
@@ -23,6 +23,7 @@ struct ProfileDebugCard: View {
         DebugRow(label: "Enable Live Activity", value: "\(profile.enableLiveActivity)")
         DebugRow(label: "Enable Breaks", value: "\(profile.enableBreaks)")
         DebugRow(label: "Break Time (minutes)", value: "\(profile.breakTimeInMinutes)")
+        DebugRow(label: "Allow Multiple Breaks", value: "\(profile.allowMultipleBreaks)")
         DebugRow(label: "Enable Strict Mode", value: "\(profile.enableStrictMode)")
         DebugRow(label: "Enable Allow Mode", value: "\(profile.enableAllowMode)")
         DebugRow(

--- a/Foqos/Components/Debug/SessionDebugCard.swift
+++ b/Foqos/Components/Debug/SessionDebugCard.swift
@@ -40,6 +40,14 @@ struct SessionDebugCard: View {
           label: "Break End Time",
           value: session.breakEndTime.map { DateFormatters.formatDate($0) } ?? "nil"
         )
+        DebugRow(
+          label: "Used Break Duration",
+          value: DateFormatters.formatDuration(session.usedBreakDurationInSeconds)
+        )
+        DebugRow(
+          label: "Remaining Break Allowance",
+          value: DateFormatters.formatDuration(session.remainingBreakAllowance())
+        )
       }
 
       Divider()

--- a/Foqos/Models/BlockedProfileSessions.swift
+++ b/Foqos/Models/BlockedProfileSessions.swift
@@ -13,6 +13,7 @@ class BlockedProfileSession {
 
   var breakStartTime: Date?
   var breakEndTime: Date?
+  var usedBreakDurationInSeconds: TimeInterval = 0
 
   var pauseStartTime: Date?
   var pauseEndTime: Date?
@@ -24,9 +25,17 @@ class BlockedProfileSession {
   }
 
   var isBreakAvailable: Bool {
-    return blockedProfile.enableBreaks == true
-      && blockedProfile.allowsTimedBreaks
-      && breakEndTime == nil
+    guard blockedProfile.enableBreaks == true,
+      blockedProfile.allowsTimedBreaks
+    else {
+      return false
+    }
+
+    if blockedProfile.allowMultipleBreaks {
+      return remainingBreakAllowance() > 0
+    }
+
+    return breakEndTime == nil
   }
 
   var isBreakActive: Bool {
@@ -45,6 +54,10 @@ class BlockedProfileSession {
     return end.timeIntervalSince(startTime)
   }
 
+  var totalBreakAllowanceInSeconds: TimeInterval {
+    TimeInterval(blockedProfile.breakTimeInMinutes * 60)
+  }
+
   init(
     tag: String,
     blockedProfile: BlockedProfiles,
@@ -60,18 +73,73 @@ class BlockedProfileSession {
     blockedProfile.sessions.append(self)
   }
 
-  func startBreak() {
-    let breakStartTime = Date()
+  func activeBreakElapsedTime(at date: Date = Date()) -> TimeInterval {
+    guard isBreakActive, let breakStartTime else {
+      return 0
+    }
+
+    return max(0, date.timeIntervalSince(breakStartTime))
+  }
+
+  func usedBreakDurationIncludingActiveBreak(at date: Date = Date()) -> TimeInterval {
+    if blockedProfile.allowMultipleBreaks {
+      return min(
+        totalBreakAllowanceInSeconds,
+        usedBreakDurationInSeconds + activeBreakElapsedTime(at: date)
+      )
+    }
+
+    return completedSingleBreakDuration(at: date)
+  }
+
+  func remainingBreakAllowance(at date: Date = Date()) -> TimeInterval {
+    max(0, totalBreakAllowanceInSeconds - usedBreakDurationIncludingActiveBreak(at: date))
+  }
+
+  func startBreak(at date: Date = Date()) {
+    let breakStartTime = date
+
+    if blockedProfile.allowMultipleBreaks {
+      SharedData.resetBreak()
+      self.breakStartTime = nil
+      self.breakEndTime = nil
+    }
 
     SharedData.setBreakStartTime(date: breakStartTime)
     self.breakStartTime = breakStartTime
   }
 
-  func endBreak() {
-    let breakEndTime = Date()
+  func endBreak(at date: Date = Date()) {
+    let breakEndTime = date
+
+    if blockedProfile.allowMultipleBreaks {
+      let completedDuration = activeBreakElapsedTime(at: breakEndTime)
+      let updatedUsedDuration = min(
+        totalBreakAllowanceInSeconds,
+        usedBreakDurationInSeconds + completedDuration
+      )
+      usedBreakDurationInSeconds = updatedUsedDuration
+      SharedData.setUsedBreakDurationInSeconds(updatedUsedDuration)
+    }
 
     SharedData.setBreakEndTime(date: breakEndTime)
     self.breakEndTime = breakEndTime
+  }
+
+  private func completedSingleBreakDuration(at date: Date) -> TimeInterval {
+    guard let breakStartTime else {
+      return 0
+    }
+
+    if let breakEndTime {
+      return max(0, breakEndTime.timeIntervalSince(breakStartTime))
+    }
+
+    if isBreakActive {
+      return max(0, date.timeIntervalSince(breakStartTime))
+    }
+
+    return 0
   }
 
   func startPause() {
@@ -107,6 +175,7 @@ class BlockedProfileSession {
       endTime: endTime,
       breakStartTime: breakStartTime,
       breakEndTime: breakEndTime,
+      usedBreakDurationInSeconds: usedBreakDurationInSeconds,
       pauseStartTime: pauseStartTime,
       pauseEndTime: pauseEndTime,
       forceStarted: forceStarted
@@ -162,6 +231,7 @@ class BlockedProfileSession {
       existingSession.endTime = snapshot.endTime
       existingSession.breakStartTime = snapshot.breakStartTime
       existingSession.breakEndTime = snapshot.breakEndTime
+      existingSession.usedBreakDurationInSeconds = snapshot.usedBreakDurationInSeconds ?? 0
       existingSession.pauseStartTime = snapshot.pauseStartTime
       existingSession.pauseEndTime = snapshot.pauseEndTime
       existingSession.forceStarted = snapshot.forceStarted
@@ -183,6 +253,7 @@ class BlockedProfileSession {
     newSession.endTime = snapshot.endTime
     newSession.breakStartTime = snapshot.breakStartTime
     newSession.breakEndTime = snapshot.breakEndTime
+    newSession.usedBreakDurationInSeconds = snapshot.usedBreakDurationInSeconds ?? 0
     newSession.pauseStartTime = snapshot.pauseStartTime
     newSession.pauseEndTime = snapshot.pauseEndTime
 

--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -19,6 +19,7 @@ class BlockedProfiles {
   var reminderTimeInSeconds: UInt32?
   var enableBreaks: Bool = false
   var breakTimeInMinutes: Int = 15
+  var allowMultipleBreaks: Bool = false
   var enableStrictMode: Bool = false
   var enableBlockAppInstallation: Bool = false
   var enableAllowMode: Bool = false
@@ -104,6 +105,7 @@ class BlockedProfiles {
     customReminderMessage: String? = nil,
     enableBreaks: Bool = false,
     breakTimeInMinutes: Int = 15,
+    allowMultipleBreaks: Bool = false,
     enableStrictMode: Bool = false,
     enableBlockAppInstallation: Bool = false,
     enableAllowMode: Bool = false,
@@ -132,6 +134,7 @@ class BlockedProfiles {
     self.enableLiveActivity = enableLiveActivity
     self.enableBreaks = enableBreaks
     self.breakTimeInMinutes = breakTimeInMinutes
+    self.allowMultipleBreaks = allowMultipleBreaks
     self.enableStrictMode = enableStrictMode
     self.enableBlockAppInstallation = enableBlockAppInstallation
     self.enableAllowMode = enableAllowMode
@@ -201,6 +204,7 @@ class BlockedProfiles {
     customReminderMessage: String? = nil,
     enableBreaks: Bool? = nil,
     breakTimeInMinutes: Int? = nil,
+    allowMultipleBreaks: Bool? = nil,
     enableStrictMode: Bool? = nil,
     enableBlockAppInstallation: Bool? = nil,
     enableAllowMode: Bool? = nil,
@@ -255,6 +259,10 @@ class BlockedProfiles {
 
     if let newBreakTimeInMinutes = breakTimeInMinutes {
       profile.breakTimeInMinutes = newBreakTimeInMinutes
+    }
+
+    if let newAllowMultipleBreaks = allowMultipleBreaks {
+      profile.allowMultipleBreaks = newAllowMultipleBreaks
     }
 
     if let newEnableStrictMode = enableStrictMode {
@@ -363,6 +371,7 @@ class BlockedProfiles {
       customReminderMessage: profile.customReminderMessage,
       enableBreaks: profile.enableBreaks,
       breakTimeInMinutes: profile.breakTimeInMinutes,
+      allowMultipleBreaks: profile.allowMultipleBreaks,
       enableStrictMode: profile.enableStrictMode,
       enableBlockAppInstallation: profile.enableBlockAppInstallation,
       enableAllowMode: profile.enableAllowMode,
@@ -420,6 +429,7 @@ class BlockedProfiles {
     customReminderMessage: String = "",
     enableBreaks: Bool = false,
     breakTimeInMinutes: Int = 15,
+    allowMultipleBreaks: Bool = false,
     enableStrictMode: Bool = false,
     enableBlockAppInstallation: Bool = false,
     enableAllowMode: Bool = false,
@@ -444,6 +454,7 @@ class BlockedProfiles {
       customReminderMessage: customReminderMessage,
       enableBreaks: enableBreaks,
       breakTimeInMinutes: breakTimeInMinutes,
+      allowMultipleBreaks: allowMultipleBreaks,
       enableStrictMode: enableStrictMode,
       enableBlockAppInstallation: enableBlockAppInstallation,
       enableAllowMode: enableAllowMode,
@@ -485,6 +496,7 @@ class BlockedProfiles {
       customReminderMessage: source.customReminderMessage,
       enableBreaks: source.enableBreaks,
       breakTimeInMinutes: source.breakTimeInMinutes,
+      allowMultipleBreaks: source.allowMultipleBreaks,
       enableStrictMode: source.enableStrictMode,
       enableBlockAppInstallation: source.enableBlockAppInstallation,
       enableAllowMode: source.enableAllowMode,

--- a/Foqos/Models/Shared.swift
+++ b/Foqos/Models/Shared.swift
@@ -29,6 +29,7 @@ enum SharedData {
     var customReminderMessage: String?
     var enableBreaks: Bool
     var breakTimeInMinutes: Int = 15
+    var allowMultipleBreaks: Bool? = nil
     var enableStrictMode: Bool
     var enableBlockAppInstallation: Bool = false
     var enableAllowMode: Bool
@@ -63,6 +64,7 @@ enum SharedData {
 
     var breakStartTime: Date?
     var breakEndTime: Date?
+    var usedBreakDurationInSeconds: TimeInterval? = nil
 
     var pauseStartTime: Date?
     var pauseEndTime: Date?
@@ -175,6 +177,32 @@ enum SharedData {
 
   static func setBreakEndTime(date: Date) {
     activeSharedSession?.breakEndTime = date
+  }
+
+  static func resetBreak() {
+    activeSharedSession?.breakStartTime = nil
+    activeSharedSession?.breakEndTime = nil
+  }
+
+  static func setUsedBreakDurationInSeconds(_ duration: TimeInterval) {
+    activeSharedSession?.usedBreakDurationInSeconds = duration
+  }
+
+  static func endBreak(date: Date, allowMultipleBreaks: Bool, totalAllowanceInSeconds: TimeInterval)
+  {
+    guard var session = activeSharedSession else { return }
+
+    if allowMultipleBreaks, let breakStartTime = session.breakStartTime {
+      let activeBreakDuration = max(0, date.timeIntervalSince(breakStartTime))
+      let existingUsedDuration = session.usedBreakDurationInSeconds ?? 0
+      session.usedBreakDurationInSeconds = min(
+        totalAllowanceInSeconds,
+        existingUsedDuration + activeBreakDuration
+      )
+    }
+
+    session.breakEndTime = date
+    activeSharedSession = session
   }
 
   static func setEndTime(date: Date) {

--- a/Foqos/Models/Timers/BreakTimerActivity.swift
+++ b/Foqos/Models/Timers/BreakTimerActivity.swift
@@ -36,9 +36,14 @@ class BreakTimerActivity: TimerActivity {
     // End restrictions for break, preserving strict mode if enabled
     appBlocker.deactivateRestrictionsForBreak(for: profile)
 
-    // End the active scheduled session
-    let now = Date()
-    SharedData.setBreakStartTime(date: now)
+    if activeSession.breakStartTime == nil || activeSession.breakEndTime != nil {
+      if profile.allowMultipleBreaks == true {
+        SharedData.resetBreak()
+      }
+
+      let now = Date()
+      SharedData.setBreakStartTime(date: now)
+    }
   }
 
   func stop(for profile: SharedData.ProfileSnapshot) {
@@ -65,7 +70,11 @@ class BreakTimerActivity: TimerActivity {
 
       // Set the break end time
       let now = Date()
-      SharedData.setBreakEndTime(date: now)
+      SharedData.endBreak(
+        date: now,
+        allowMultipleBreaks: profile.allowMultipleBreaks == true,
+        totalAllowanceInSeconds: TimeInterval(profile.breakTimeInMinutes * 60)
+      )
     }
   }
 }

--- a/Foqos/Utils/DeviceActivityCenterUtil.swift
+++ b/Foqos/Utils/DeviceActivityCenterUtil.swift
@@ -37,12 +37,21 @@ class DeviceActivityCenterUtil {
   }
 
   static func startBreakTimerActivity(for profile: BlockedProfiles) {
+    startBreakTimerActivity(
+      for: profile,
+      durationInSeconds: TimeInterval(profile.breakTimeInMinutes * 60)
+    )
+  }
+
+  static func startBreakTimerActivity(
+    for profile: BlockedProfiles,
+    durationInSeconds: TimeInterval
+  ) {
     let center = DeviceActivityCenter()
     let breakTimerActivity = BreakTimerActivity()
     let deviceActivityName = breakTimerActivity.getDeviceActivityName(from: profile.id.uuidString)
 
-    let (intervalStart, intervalEnd) = getTimeIntervalStartAndEnd(
-      from: profile.breakTimeInMinutes)
+    let (intervalStart, intervalEnd) = getTimeIntervalStartAndEnd(from: durationInSeconds)
     let deviceActivitySchedule = DeviceActivitySchedule(
       intervalStart: intervalStart,
       intervalEnd: intervalEnd,
@@ -72,7 +81,7 @@ class DeviceActivityCenterUtil {
       from: profile.id.uuidString)
 
     let (intervalStart, intervalEnd) = getTimeIntervalStartAndEnd(
-      from: timerData.durationInMinutes)
+      from: TimeInterval(timerData.durationInMinutes * 60))
 
     let deviceActivitySchedule = DeviceActivitySchedule(
       intervalStart: intervalStart,
@@ -137,7 +146,7 @@ class DeviceActivityCenterUtil {
       from: profile.id.uuidString)
 
     let (intervalStart, intervalEnd) = getTimeIntervalStartAndEnd(
-      from: pauseData.pauseDurationInMinutes)
+      from: TimeInterval(pauseData.pauseDurationInMinutes * 60))
 
     let deviceActivitySchedule = DeviceActivitySchedule(
       intervalStart: intervalStart,
@@ -208,29 +217,18 @@ class DeviceActivityCenterUtil {
     center.stopMonitoring(activities)
   }
 
-  private static func getTimeIntervalStartAndEnd(from minutes: Int) -> (
+  private static func getTimeIntervalStartAndEnd(from durationInSeconds: TimeInterval) -> (
     intervalStart: DateComponents, intervalEnd: DateComponents
   ) {
-    let intervalStart = DateComponents(hour: 0, minute: 0)
+    let intervalStart = DateComponents(hour: 0, minute: 0, second: 0)
 
-    // Get current time
     let now = Date()
-    let currentComponents = Calendar.current.dateComponents([.hour, .minute], from: now)
-    let currentHour = currentComponents.hour ?? 0
-    let currentMinute = currentComponents.minute ?? 0
-
-    // Calculate end time by adding minutes to current time
-    let totalMinutes = currentMinute + minutes
-    var endHour = currentHour + (totalMinutes / 60)
-    var endMinute = totalMinutes % 60
-
-    // Cap at 23:59 if it would roll over past midnight.
-    if endHour >= 24 || (endHour == 23 && endMinute >= 59) {
-      endHour = 23
-      endMinute = 59
-    }
-
-    let intervalEnd = DateComponents(hour: endHour, minute: endMinute)
+    let safeDuration = max(1, durationInSeconds)
+    let endDate = min(
+      now.addingTimeInterval(safeDuration),
+      Calendar.current.startOfDay(for: now).addingTimeInterval((24 * 60 * 60) - 1)
+    )
+    let intervalEnd = Calendar.current.dateComponents([.hour, .minute, .second], from: endDate)
     return (intervalStart: intervalStart, intervalEnd: intervalEnd)
   }
 }

--- a/Foqos/Utils/LiveActivityManager.swift
+++ b/Foqos/Utils/LiveActivityManager.swift
@@ -191,6 +191,7 @@ class LiveActivityManager: ObservableObject {
       isBreakActive: session.isBreakActive,
       breakStartTime: session.breakStartTime,
       breakEndTime: session.breakEndTime,
+      usedBreakDurationInSeconds: session.usedBreakDurationInSeconds,
       isPauseActive: session.isPauseActive,
       pauseStartTime: session.pauseStartTime,
       pauseEndTime: session.pauseEndTime

--- a/Foqos/Utils/SessionTimeCalculator.swift
+++ b/Foqos/Utils/SessionTimeCalculator.swift
@@ -34,8 +34,12 @@ enum SessionTimeCalculator {
     }
 
     if let breakStartTime = session.breakStartTime, session.isBreakActive {
-      return breakStartTime.addingTimeInterval(
-        TimeInterval(session.blockedProfile.breakTimeInMinutes * 60))
+      if session.blockedProfile.allowMultipleBreaks {
+        let remainingAllowanceAtBreakStart = session.remainingBreakAllowance(at: breakStartTime)
+        return breakStartTime.addingTimeInterval(remainingAllowanceAtBreakStart)
+      }
+
+      return breakStartTime.addingTimeInterval(session.totalBreakAllowanceInSeconds)
     }
 
     if isScheduledSession(session), let schedule = session.blockedProfile.schedule {
@@ -82,6 +86,10 @@ enum SessionTimeCalculator {
     for session: BlockedProfileSession,
     at date: Date
   ) -> TimeInterval {
+    if session.blockedProfile.allowMultipleBreaks {
+      return session.usedBreakDurationIncludingActiveBreak(at: date)
+    }
+
     guard let breakStartTime = session.breakStartTime else {
       return 0
     }

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -447,17 +447,33 @@ class StrategyManager: ObservableObject {
       return
     }
 
+    let remainingBreakAllowance = session.remainingBreakAllowance()
+    guard remainingBreakAllowance > 0 else {
+      print("No break allowance remaining")
+      return
+    }
+
+    session.startBreak()
+    appBlocker.deactivateRestrictionsForBreak(
+      for: BlockedProfiles.getSnapshot(for: session.blockedProfile))
+    try? context.save()
+
     // Start the break timer activity
-    DeviceActivityCenterUtil.startBreakTimerActivity(for: session.blockedProfile)
+    DeviceActivityCenterUtil.startBreakTimerActivity(
+      for: session.blockedProfile,
+      durationInSeconds: remainingBreakAllowance
+    )
 
     // Schedule a reminder to get back to the profile after the break
-    scheduleBreakReminder(profile: session.blockedProfile)
+    scheduleBreakReminder(
+      profile: session.blockedProfile,
+      durationInSeconds: remainingBreakAllowance
+    )
 
     // Refresh widgets when break starts
     WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
 
-    // Load the active session since the break start time was set in a different thread
-    loadActiveSession(context: context)
+    updateSessionTimes()
 
     // Update live activity to show break state
     liveActivityManager.updateBreakState(session: session)
@@ -469,10 +485,14 @@ class StrategyManager: ObservableObject {
       return
     }
 
-    if !session.isBreakAvailable {
+    if !session.isBreakActive {
       print("Breaks is not availble")
       return
     }
+
+    session.endBreak()
+    appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: session.blockedProfile))
+    try? context.save()
 
     // Remove the break timer activity
     DeviceActivityCenterUtil.removeBreakTimerActivity(for: session.blockedProfile)
@@ -483,8 +503,7 @@ class StrategyManager: ObservableObject {
     // Refresh widgets when break ends
     WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
 
-    // Load the active session since the break end time was set in a different thread
-    loadActiveSession(context: context)
+    updateSessionTimes()
 
     // Update live activity to show break has ended
     liveActivityManager.updateBreakState(session: session)
@@ -674,16 +693,20 @@ class StrategyManager: ObservableObject {
       )
   }
 
-  private func scheduleBreakReminder(profile: BlockedProfiles) {
+  private func scheduleBreakReminder(
+    profile: BlockedProfiles,
+    durationInSeconds: TimeInterval? = nil
+  ) {
     let profileName = profile.name
 
     // Schedule a reminder to let the user know that the break is about to end
-    let breakNotificationTimeInSeconds = UInt32((profile.breakTimeInMinutes - 1) * 60)
+    let breakDurationInSeconds = durationInSeconds ?? TimeInterval(profile.breakTimeInMinutes * 60)
+    let breakNotificationTimeInSeconds = breakDurationInSeconds - 60
     if breakNotificationTimeInSeconds > 0 {
       timersUtil.scheduleNotification(
         title: "Break almost over!",
         message: "Hope you enjoyed your break, starting " + profileName + " in 1 minute.",
-        seconds: TimeInterval(breakNotificationTimeInSeconds)
+        seconds: breakNotificationTimeInSeconds
       )
     }
   }

--- a/Foqos/Views/DebugView.swift
+++ b/Foqos/Views/DebugView.swift
@@ -143,6 +143,10 @@ struct DebugView: View {
 
       markdown += "- **Break Available:** \(session.isBreakAvailable ? "Yes" : "No")\n"
       markdown += "- **Break Active:** \(session.isBreakActive ? "Yes" : "No")\n"
+      markdown +=
+        "- **Used Break Duration:** \(DateFormatters.formatDuration(session.usedBreakDurationInSeconds))\n"
+      markdown +=
+        "- **Remaining Break Allowance:** \(DateFormatters.formatDuration(session.remainingBreakAllowance()))\n"
 
       if let breakStartTime = session.breakStartTime {
         markdown += "- **Break Started At:** \(DateFormatters.formatDate(breakStartTime))\n"
@@ -196,6 +200,8 @@ struct DebugView: View {
           "- **Adult Content Blocking:** \(profile.enableAdultContentBlocking ? "Enabled" : "Disabled")\n"
         markdown += "- **Live Activity:** \(profile.enableLiveActivity ? "Enabled" : "Disabled")\n"
         markdown += "- **Breaks:** \(profile.enableBreaks ? "Enabled" : "Disabled")\n"
+        markdown +=
+          "- **Allow Multiple Breaks:** \(profile.allowMultipleBreaks ? "Enabled" : "Disabled")\n"
         markdown += "- **Strict Mode:** \(profile.enableStrictMode ? "Enabled" : "Disabled")\n"
         markdown +=
           "- **Prevent App Installation:** \(profile.enableBlockAppInstallation ? "Enabled" : "Disabled")\n"

--- a/Foqos/Views/GuidedBlockedProfileCreationView.swift
+++ b/Foqos/Views/GuidedBlockedProfileCreationView.swift
@@ -516,7 +516,15 @@ private struct GuidedProfileReviewContent: View {
       return "Not needed"
     }
 
-    return draft.enableBreaks ? "\(draft.breakTimeInMinutes) minutes" : "Disabled"
+    guard draft.enableBreaks else {
+      return "Disabled"
+    }
+
+    if draft.allowMultipleBreaks {
+      return "\(draft.breakTimeInMinutes) minutes, reusable"
+    }
+
+    return "\(draft.breakTimeInMinutes) minutes"
   }
 
   private var safeguardsSummary: String {

--- a/FoqosWidget/FoqosWidgetLiveActivity.swift
+++ b/FoqosWidget/FoqosWidgetLiveActivity.swift
@@ -9,6 +9,7 @@ struct FoqosWidgetAttributes: ActivityAttributes {
     var isBreakActive: Bool = false
     var breakStartTime: Date?
     var breakEndTime: Date?
+    var usedBreakDurationInSeconds: TimeInterval = 0
     var isPauseActive: Bool = false
     var pauseStartTime: Date?
     var pauseEndTime: Date?
@@ -26,16 +27,14 @@ struct FoqosWidgetAttributes: ActivityAttributes {
 
     private func calculateBreakDuration() -> TimeInterval {
       guard let breakStart = breakStartTime else {
-        return 0
+        return usedBreakDurationInSeconds
       }
 
       if let breakEnd = breakEndTime {
-        // Break is complete, return the full duration
-        return breakEnd.timeIntervalSince(breakStart)
+        return usedBreakDurationInSeconds + breakEnd.timeIntervalSince(breakStart)
       }
 
-      // Break is not yet ended, don't count it
-      return 0
+      return usedBreakDurationInSeconds
     }
 
     var countdownRange: ClosedRange<Date>? {
@@ -315,6 +314,7 @@ extension FoqosWidgetAttributes.ContentState {
         isBreakActive: false,
         breakStartTime: nil,
         breakEndTime: nil,
+        usedBreakDurationInSeconds: 0,
         isPauseActive: false,
         pauseStartTime: nil,
         pauseEndTime: nil
@@ -328,6 +328,7 @@ extension FoqosWidgetAttributes.ContentState {
       isBreakActive: false,
       breakStartTime: nil,
       breakEndTime: nil,
+      usedBreakDurationInSeconds: 0,
       isPauseActive: false,
       pauseStartTime: nil,
       pauseEndTime: nil
@@ -341,6 +342,7 @@ extension FoqosWidgetAttributes.ContentState {
       isBreakActive: true,
       breakStartTime: Date.now,
       breakEndTime: nil,
+      usedBreakDurationInSeconds: 0,
       isPauseActive: false,
       pauseStartTime: nil,
       pauseEndTime: nil
@@ -354,6 +356,7 @@ extension FoqosWidgetAttributes.ContentState {
       isBreakActive: false,
       breakStartTime: nil,
       breakEndTime: nil,
+      usedBreakDurationInSeconds: 0,
       isPauseActive: true,
       pauseStartTime: Date.now,
       pauseEndTime: nil

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Foqos is not affiliated with Brick, Unpluq, Blok, or Opal.
 - NFC tag blocking for physical start and stop flows
 - QR code and barcode blocking, including generated profile QR codes
 - Timer-based sessions that end automatically after a chosen duration
+- Optional reusable break allowance that can be split across multiple breaks in a session
 - Physical unlock rules for profiles that should only stop with approved tags or codes
 - Temporary Access strategies for limited, short opens without ending the full session
-- Pause Timer strategies for a short break before blocking resumes
+- Pause Timer strategies for a short pause before blocking resumes
 - Smart breaks, session history, focus streaks, and profile insights
 - Live Activities for Lock Screen and Dynamic Island status
 - Widgets and App Intents for faster profile control

--- a/foqosTests/SessionTimeCalculatorTests.swift
+++ b/foqosTests/SessionTimeCalculatorTests.swift
@@ -70,10 +70,121 @@ final class SessionTimeCalculatorTests: XCTestCase {
     )
   }
 
+  func testSingleBreakIsUnavailableAfterItEnds() {
+    let startTime = Date(timeIntervalSinceReferenceDate: 1_000)
+    let profile = makeProfile(
+      strategyId: ManualBlockingStrategy.id,
+      enableBreaks: true,
+      breakTimeInMinutes: 15,
+      allowMultipleBreaks: false
+    )
+    let session = BlockedProfileSession(
+      tag: ManualBlockingStrategy.id,
+      blockedProfile: profile
+    )
+    session.startTime = startTime
+    session.breakStartTime = startTime.addingTimeInterval(5 * 60)
+    session.breakEndTime = startTime.addingTimeInterval(8 * 60)
+
+    XCTAssertFalse(session.isBreakAvailable)
+    XCTAssertEqual(
+      SessionTimeCalculator.elapsedFocusTime(
+        for: session,
+        at: startTime.addingTimeInterval(10 * 60)
+      ),
+      7 * 60,
+      accuracy: 0.1
+    )
+  }
+
+  func testReusableBreakStoppedEarlyLeavesRemainingAllowance() {
+    let startTime = Date(timeIntervalSinceReferenceDate: 1_000)
+    let profile = makeProfile(
+      strategyId: ManualBlockingStrategy.id,
+      enableBreaks: true,
+      breakTimeInMinutes: 15,
+      allowMultipleBreaks: true
+    )
+    let session = BlockedProfileSession(
+      tag: ManualBlockingStrategy.id,
+      blockedProfile: profile
+    )
+    session.startTime = startTime
+    session.breakStartTime = startTime.addingTimeInterval(5 * 60)
+    session.breakEndTime = startTime.addingTimeInterval(8 * 60)
+    session.usedBreakDurationInSeconds = 3 * 60
+
+    XCTAssertTrue(session.isBreakAvailable)
+    XCTAssertEqual(session.remainingBreakAllowance(), 12 * 60, accuracy: 0.1)
+  }
+
+  func testReusableBreakDisplaysRemainingAllowanceDuringSecondBreak() {
+    let startTime = Date(timeIntervalSinceReferenceDate: 1_000)
+    let profile = makeProfile(
+      strategyId: ManualBlockingStrategy.id,
+      enableBreaks: true,
+      breakTimeInMinutes: 15,
+      allowMultipleBreaks: true
+    )
+    let session = BlockedProfileSession(
+      tag: ManualBlockingStrategy.id,
+      blockedProfile: profile
+    )
+    session.startTime = startTime
+    session.usedBreakDurationInSeconds = 3 * 60
+    session.breakStartTime = startTime.addingTimeInterval(10 * 60)
+
+    let currentTime = startTime.addingTimeInterval(12 * 60)
+    let elapsedTime = SessionTimeCalculator.elapsedFocusTime(for: session, at: currentTime)
+    let displayTime = SessionTimeCalculator.displayedTime(
+      for: session,
+      elapsedFocusTime: elapsedTime,
+      at: currentTime
+    )
+
+    XCTAssertEqual(elapsedTime, 7 * 60, accuracy: 0.1)
+    XCTAssertEqual(displayTime, 10 * 60, accuracy: 0.1)
+  }
+
+  func testReusableBreakUnavailableWhenAllowanceIsExhausted() {
+    let profile = makeProfile(
+      strategyId: ManualBlockingStrategy.id,
+      enableBreaks: true,
+      breakTimeInMinutes: 15,
+      allowMultipleBreaks: true
+    )
+    let session = BlockedProfileSession(
+      tag: ManualBlockingStrategy.id,
+      blockedProfile: profile
+    )
+    session.usedBreakDurationInSeconds = 15 * 60
+
+    XCTAssertFalse(session.isBreakAvailable)
+    XCTAssertEqual(session.remainingBreakAllowance(), 0, accuracy: 0.1)
+  }
+
+  func testReusableBreakAllowanceResetsForNewSession() {
+    let profile = makeProfile(
+      strategyId: ManualBlockingStrategy.id,
+      enableBreaks: true,
+      breakTimeInMinutes: 15,
+      allowMultipleBreaks: true
+    )
+    let session = BlockedProfileSession(
+      tag: ManualBlockingStrategy.id,
+      blockedProfile: profile
+    )
+
+    XCTAssertTrue(session.isBreakAvailable)
+    XCTAssertEqual(session.remainingBreakAllowance(), 15 * 60, accuracy: 0.1)
+  }
+
   private func makeProfile(
     strategyId: String,
     durationInMinutes: Int? = nil,
-    enableBreaks: Bool = false
+    enableBreaks: Bool = false,
+    breakTimeInMinutes: Int = 15,
+    allowMultipleBreaks: Bool = false
   ) -> BlockedProfiles {
     let strategyData = durationInMinutes.flatMap {
       StrategyTimerData.toData(
@@ -85,7 +196,9 @@ final class SessionTimeCalculatorTests: XCTestCase {
       name: "Focus",
       blockingStrategyId: strategyId,
       strategyData: strategyData,
-      enableBreaks: enableBreaks
+      enableBreaks: enableBreaks,
+      breakTimeInMinutes: breakTimeInMinutes,
+      allowMultipleBreaks: allowMultipleBreaks
     )
   }
 }


### PR DESCRIPTION
# Add reusable break allowance

## Summary

- Adds an opt-in **Allow Multiple Breaks** setting under timed breaks.
- Keeps the existing single-break behavior as the default when the new setting is off.
- Tracks used break duration per blocking session so the configured break duration can be spent across multiple breaks.
- Starts reusable breaks from the remaining allowance and updates timers, reminders, shared session snapshots, Live Activities, and debug views.
- Adds unit coverage for single-break behavior, early reusable break stops, second-break countdowns, exhausted allowance, and new-session reset behavior.

## Screenshot

![Allow Multiple Breaks setting](https://raw.githubusercontent.com/martynasali/foqos/pr-screenshot-424/pr-assets/allow-multiple-breaks-screenshot.png)

The screenshot shows the new **Allow Multiple Breaks** toggle below **Break Duration**. When enabled, the selected break duration becomes a session-scoped allowance that can be split across multiple breaks instead of being consumed by one break attempt.

## Validation

- `PATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:$PATH" make lint`
  - Passed with existing unrelated swift-format warnings.
- `make build`
  - Passed.
  - Existing warning remains: app extension `CFBundleShortVersionString` is `2.0.7` while the parent app is `2.1.0`.
- `make test`
  - Passed.
