### PR TITLE
Add companion device support over Bluetooth LE

### DIFF
--- a/Foqos/Info.plist
+++ b/Foqos/Info.plist
@@ -18,6 +18,7 @@
 	<false/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>bluetooth-central</string>
 		<string>fetch</string>
 		<string>processing</string>
 	</array>

--- a/Foqos/Models/CompanionStatusPayload.swift
+++ b/Foqos/Models/CompanionStatusPayload.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-// Packed status payload written to the ESP32 companion's status
-// characteristic. Layout is shared byte-for-byte with the firmware decoder
-// (esp32-companion/src/status_model.cpp); bump the version when it changes.
+// Packed status payload written to the companion device's status
+// characteristic. The byte layout is the contract documented in
+// docs/companion-device-protocol.md; bump the version when it changes.
 struct CompanionStatusPayload: Equatable {
   static let version: UInt8 = 2
   static let profileNameMaxBytes = 64

--- a/Foqos/Models/CompanionStatusPayload.swift
+++ b/Foqos/Models/CompanionStatusPayload.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+// Packed status payload written to the ESP32 companion's status
+// characteristic. Layout is shared byte-for-byte with the firmware decoder
+// (esp32-companion/src/status_model.cpp); bump the version when it changes.
+struct CompanionStatusPayload: Equatable {
+  static let version: UInt8 = 1
+  static let profileNameMaxBytes = 64
+  // version(1) + flags(1) + startEpoch(8) + endEpoch(8) + name(64)
+  static let encodedSize = 2 + 8 + 8 + profileNameMaxBytes
+
+  var isActive: Bool
+  var isBreakActive: Bool
+  var isPauseActive: Bool
+  var sessionStartEpoch: Int64
+  var expectedEndEpoch: Int64
+  var profileName: String
+
+  static let inactive = CompanionStatusPayload(
+    isActive: false,
+    isBreakActive: false,
+    isPauseActive: false,
+    sessionStartEpoch: 0,
+    expectedEndEpoch: 0,
+    profileName: ""
+  )
+
+  func encoded() -> Data {
+    var data = Data(capacity: Self.encodedSize)
+    data.append(Self.version)
+
+    var flags: UInt8 = 0
+    if isActive { flags |= 1 << 0 }
+    if isBreakActive { flags |= 1 << 1 }
+    if isPauseActive { flags |= 1 << 2 }
+    data.append(flags)
+
+    appendLittleEndian(sessionStartEpoch, to: &data)
+    appendLittleEndian(expectedEndEpoch, to: &data)
+    data.append(encodedProfileName())
+
+    return data
+  }
+
+  // UTF-8 bytes truncated at a scalar boundary so the firmware never sees a
+  // dangling continuation byte, then null-padded to the fixed field width.
+  private func encodedProfileName() -> Data {
+    var bytes = Data(capacity: Self.profileNameMaxBytes)
+    for scalar in profileName.unicodeScalars {
+      let encoded = Array(String(scalar).utf8)
+      if bytes.count + encoded.count > Self.profileNameMaxBytes { break }
+      bytes.append(contentsOf: encoded)
+    }
+    bytes.append(Data(repeating: 0, count: Self.profileNameMaxBytes - bytes.count))
+    return bytes
+  }
+
+  private func appendLittleEndian(_ value: Int64, to data: inout Data) {
+    withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+  }
+}

--- a/Foqos/Models/CompanionStatusPayload.swift
+++ b/Foqos/Models/CompanionStatusPayload.swift
@@ -4,10 +4,12 @@ import Foundation
 // characteristic. Layout is shared byte-for-byte with the firmware decoder
 // (esp32-companion/src/status_model.cpp); bump the version when it changes.
 struct CompanionStatusPayload: Equatable {
-  static let version: UInt8 = 1
+  static let version: UInt8 = 2
   static let profileNameMaxBytes = 64
+  static let weekDayCount = 7
   // version(1) + flags(1) + startEpoch(8) + endEpoch(8) + name(64)
-  static let encodedSize = 2 + 8 + 8 + profileNameMaxBytes
+  //   + streak(2) + todaySeconds(4) + weekMinutes(7*2)
+  static let encodedSize = 2 + 8 + 8 + profileNameMaxBytes + 2 + 4 + weekDayCount * 2
 
   var isActive: Bool
   var isBreakActive: Bool
@@ -15,6 +17,9 @@ struct CompanionStatusPayload: Equatable {
   var sessionStartEpoch: Int64
   var expectedEndEpoch: Int64
   var profileName: String
+  var streakDays: UInt16 = 0
+  var todayFocusSeconds: UInt32 = 0
+  var weekMinutes: [UInt16] = []  // oldest first, last entry = today
 
   static let inactive = CompanionStatusPayload(
     isActive: false,
@@ -38,6 +43,13 @@ struct CompanionStatusPayload: Equatable {
     appendLittleEndian(sessionStartEpoch, to: &data)
     appendLittleEndian(expectedEndEpoch, to: &data)
     data.append(encodedProfileName())
+
+    withUnsafeBytes(of: streakDays.littleEndian) { data.append(contentsOf: $0) }
+    withUnsafeBytes(of: todayFocusSeconds.littleEndian) { data.append(contentsOf: $0) }
+    for day in 0..<Self.weekDayCount {
+      let minutes = day < weekMinutes.count ? weekMinutes[day] : 0
+      withUnsafeBytes(of: minutes.littleEndian) { data.append(contentsOf: $0) }
+    }
 
     return data
   }

--- a/Foqos/Utils/CompanionDeviceManager.swift
+++ b/Foqos/Utils/CompanionDeviceManager.swift
@@ -1,0 +1,352 @@
+import CoreBluetooth
+import SwiftUI
+
+// Pushes blocking session status to an ESP32 companion device over BLE and
+// points its NFC tag at a profile deep link. Opt-in: no CBCentralManager (and
+// therefore no Bluetooth permission prompt) exists until the user enables the
+// feature in settings. GATT contract lives in esp32-companion/README.md.
+class CompanionDeviceManager: NSObject, ObservableObject {
+  static let shared = CompanionDeviceManager()
+
+  static let serviceUUID = CBUUID(string: "F0C50001-8B1E-4B6D-9F26-3F0B5C7A1D01")
+  static let statusCharacteristicUUID = CBUUID(string: "F0C50002-8B1E-4B6D-9F26-3F0B5C7A1D01")
+  static let timeSyncCharacteristicUUID = CBUUID(string: "F0C50003-8B1E-4B6D-9F26-3F0B5C7A1D01")
+  static let tagConfigCharacteristicUUID = CBUUID(string: "F0C50004-8B1E-4B6D-9F26-3F0B5C7A1D01")
+  static let toggleCharacteristicUUID = CBUUID(string: "F0C50005-8B1E-4B6D-9F26-3F0B5C7A1D01")
+  private static let restoreIdentifier = "dev.ambitionsoftware.foqos.companionCentral"
+
+  @AppStorage("companionDeviceEnabled") private(set) var isEnabled: Bool = false
+  @AppStorage("companionDeviceIdentifier") private var pairedIdentifier: String = ""
+  @AppStorage("companionDeviceName") private(set) var pairedDeviceName: String = ""
+  @AppStorage("companionDeviceProfileId") var tagProfileId: String = ""
+
+  @Published var isConnected: Bool = false
+  @Published var isScanning: Bool = false
+  @Published var discoveredPeripherals: [CBPeripheral] = []
+
+  // Fired when the device asks to toggle the session (e.g. a screen tap),
+  // passing the profile configured for the device's tag. Wired in foqosApp.
+  var onToggleRequested: ((UUID?) -> Void)?
+
+  private var centralManager: CBCentralManager?
+  private var connectedPeripheral: CBPeripheral?
+  private var statusCharacteristic: CBCharacteristic?
+  private var timeSyncCharacteristic: CBCharacteristic?
+  private var tagConfigCharacteristic: CBCharacteristic?
+
+  // Latest truth is kept (not consumed) so sessions toggled while the device
+  // is out of range reconcile on reconnect, and every reconnect re-pushes in
+  // case the device power-cycled and lost its RAM state.
+  private var currentStatus: CompanionStatusPayload?
+  private var statusDirty = false
+  private var pendingTagConfigURL: String?
+  private var wantsScanning = false
+  private var lastToggleRequestAt: Date = .distantPast
+
+  var isPaired: Bool {
+    return !pairedIdentifier.isEmpty
+  }
+
+  private override init() {
+    super.init()
+  }
+
+  // Called on app launch; reconnects to a previously paired device.
+  func start() {
+    guard isEnabled, isPaired else { return }
+    ensureCentralManager()
+  }
+
+  func setEnabled(_ enabled: Bool) {
+    isEnabled = enabled
+    if enabled {
+      ensureCentralManager()
+    } else {
+      stopScanning()
+      disconnect()
+      centralManager = nil
+    }
+  }
+
+  // MARK: - Pairing
+
+  func startScanning() {
+    guard isEnabled else { return }
+    ensureCentralManager()
+    wantsScanning = true
+    discoveredPeripherals = []
+    scanIfPoweredOn()
+  }
+
+  func stopScanning() {
+    wantsScanning = false
+    isScanning = false
+    centralManager?.stopScan()
+  }
+
+  func pair(_ peripheral: CBPeripheral) {
+    stopScanning()
+    pairedIdentifier = peripheral.identifier.uuidString
+    pairedDeviceName = peripheral.name ?? "Foqos Companion"
+    connect(to: peripheral)
+  }
+
+  func unpair() {
+    disconnect()
+    pairedIdentifier = ""
+    pairedDeviceName = ""
+    tagProfileId = ""
+    currentStatus = nil
+    statusDirty = false
+    pendingTagConfigURL = nil
+  }
+
+  // MARK: - Pushes
+
+  func pushStatus(session: BlockedProfileSession?) {
+    guard isEnabled, isPaired else { return }
+    let payload = makePayload(for: session)
+    if payload == currentStatus && !statusDirty { return }
+    currentStatus = payload
+    statusDirty = true
+    flushPendingWrites()
+  }
+
+  func pushSessionEnded() {
+    pushStatus(session: nil)
+  }
+
+  func pushTagConfig(profile: BlockedProfiles) {
+    guard isEnabled, isPaired else { return }
+    tagProfileId = profile.id.uuidString
+    pendingTagConfigURL = BlockedProfiles.getProfileDeepLink(profile)
+    flushPendingWrites()
+  }
+
+  // MARK: - Internals
+
+  private func makePayload(for session: BlockedProfileSession?) -> CompanionStatusPayload {
+    guard let session = session, session.isActive else {
+      return .inactive
+    }
+
+    let expectedEnd = SessionTimeCalculator.expectedEndTime(for: session)
+    return CompanionStatusPayload(
+      isActive: true,
+      isBreakActive: session.isBreakActive,
+      isPauseActive: session.isPauseActive,
+      sessionStartEpoch: Int64(session.startTime.timeIntervalSince1970),
+      expectedEndEpoch: expectedEnd.map { Int64($0.timeIntervalSince1970) } ?? 0,
+      profileName: session.blockedProfile.name
+    )
+  }
+
+  private func ensureCentralManager() {
+    guard centralManager == nil else { return }
+    centralManager = CBCentralManager(
+      delegate: self,
+      queue: nil,
+      options: [CBCentralManagerOptionRestoreIdentifierKey: Self.restoreIdentifier]
+    )
+  }
+
+  private func scanIfPoweredOn() {
+    guard wantsScanning, centralManager?.state == .poweredOn else { return }
+    isScanning = true
+    centralManager?.scanForPeripherals(withServices: [Self.serviceUUID])
+  }
+
+  private func reconnectPairedPeripheral() {
+    guard let central = centralManager,
+      central.state == .poweredOn,
+      let identifier = UUID(uuidString: pairedIdentifier),
+      connectedPeripheral == nil
+    else { return }
+
+    if let peripheral = central.retrievePeripherals(withIdentifiers: [identifier]).first {
+      connect(to: peripheral)
+    }
+  }
+
+  private func connect(to peripheral: CBPeripheral) {
+    connectedPeripheral = peripheral
+    peripheral.delegate = self
+    // Pending connects persist until the device comes into range, at no cost.
+    centralManager?.connect(peripheral)
+  }
+
+  private func disconnect() {
+    if let peripheral = connectedPeripheral {
+      centralManager?.cancelPeripheralConnection(peripheral)
+    }
+    connectedPeripheral = nil
+    statusCharacteristic = nil
+    timeSyncCharacteristic = nil
+    tagConfigCharacteristic = nil
+    isConnected = false
+  }
+
+  private func flushPendingWrites() {
+    guard let peripheral = connectedPeripheral, peripheral.state == .connected else {
+      reconnectPairedPeripheral()
+      return
+    }
+
+    if statusDirty, let status = currentStatus, let characteristic = statusCharacteristic {
+      peripheral.writeValue(status.encoded(), for: characteristic, type: .withResponse)
+      statusDirty = false
+    }
+
+    if let url = pendingTagConfigURL, let characteristic = tagConfigCharacteristic,
+      let data = url.data(using: .utf8)
+    {
+      peripheral.writeValue(data, for: characteristic, type: .withResponse)
+      pendingTagConfigURL = nil
+    }
+  }
+
+  private func writeTimeSync(to peripheral: CBPeripheral) {
+    guard let characteristic = timeSyncCharacteristic else { return }
+    var epoch = Int64(Date().timeIntervalSince1970).littleEndian
+    let data = withUnsafeBytes(of: &epoch) { Data($0) }
+    peripheral.writeValue(data, for: characteristic, type: .withResponse)
+  }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension CompanionDeviceManager: CBCentralManagerDelegate {
+  func centralManagerDidUpdateState(_ central: CBCentralManager) {
+    switch central.state {
+    case .poweredOn:
+      scanIfPoweredOn()
+      if let peripheral = connectedPeripheral, peripheral.state == .connected {
+        // Restored by iOS while already connected; didConnect will not fire
+        // again, so resume service discovery here.
+        isConnected = true
+        peripheral.discoverServices([Self.serviceUUID])
+      } else {
+        reconnectPairedPeripheral()
+      }
+    default:
+      isConnected = false
+    }
+  }
+
+  func centralManager(
+    _ central: CBCentralManager, willRestoreState dict: [String: Any]
+  ) {
+    // iOS relaunched us for a BLE event; re-adopt the peripheral it kept.
+    let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] ?? []
+    if let peripheral = peripherals.first(where: {
+      $0.identifier.uuidString == pairedIdentifier
+    }) {
+      connectedPeripheral = peripheral
+      peripheral.delegate = self
+    }
+  }
+
+  func centralManager(
+    _ central: CBCentralManager,
+    didDiscover peripheral: CBPeripheral,
+    advertisementData: [String: Any],
+    rssi: NSNumber
+  ) {
+    if !discoveredPeripherals.contains(where: { $0.identifier == peripheral.identifier }) {
+      discoveredPeripherals.append(peripheral)
+    }
+  }
+
+  func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+    isConnected = true
+    peripheral.discoverServices([Self.serviceUUID])
+  }
+
+  func centralManager(
+    _ central: CBCentralManager,
+    didDisconnectPeripheral peripheral: CBPeripheral,
+    error: Error?
+  ) {
+    isConnected = false
+    statusCharacteristic = nil
+    timeSyncCharacteristic = nil
+    tagConfigCharacteristic = nil
+
+    // Re-issue the connect so iOS delivers the device when it reappears.
+    if isEnabled, isPaired {
+      centralManager?.connect(peripheral)
+    }
+  }
+
+  func centralManager(
+    _ central: CBCentralManager,
+    didFailToConnect peripheral: CBPeripheral,
+    error: Error?
+  ) {
+    isConnected = false
+    if isEnabled, isPaired {
+      centralManager?.connect(peripheral)
+    }
+  }
+}
+
+// MARK: - CBPeripheralDelegate
+
+extension CompanionDeviceManager: CBPeripheralDelegate {
+  func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+    guard let service = peripheral.services?.first(where: { $0.uuid == Self.serviceUUID })
+    else { return }
+    peripheral.discoverCharacteristics(
+      [
+        Self.statusCharacteristicUUID,
+        Self.timeSyncCharacteristicUUID,
+        Self.tagConfigCharacteristicUUID,
+        Self.toggleCharacteristicUUID,
+      ],
+      for: service
+    )
+  }
+
+  func peripheral(
+    _ peripheral: CBPeripheral,
+    didDiscoverCharacteristicsFor service: CBService,
+    error: Error?
+  ) {
+    for characteristic in service.characteristics ?? [] {
+      switch characteristic.uuid {
+      case Self.statusCharacteristicUUID:
+        statusCharacteristic = characteristic
+      case Self.timeSyncCharacteristicUUID:
+        timeSyncCharacteristic = characteristic
+      case Self.tagConfigCharacteristicUUID:
+        tagConfigCharacteristic = characteristic
+      case Self.toggleCharacteristicUUID:
+        // Toggle requests wake the app in the background via this subscription
+        peripheral.setNotifyValue(true, for: characteristic)
+      default:
+        break
+      }
+    }
+
+    // The device has no RTC: sync the wall clock, then re-push the current
+    // truth (the device may have rebooted since the last write).
+    writeTimeSync(to: peripheral)
+    statusDirty = currentStatus != nil
+    flushPendingWrites()
+  }
+
+  func peripheral(
+    _ peripheral: CBPeripheral,
+    didUpdateValueFor characteristic: CBCharacteristic,
+    error: Error?
+  ) {
+    guard characteristic.uuid == Self.toggleCharacteristicUUID, error == nil else { return }
+
+    // Debounce duplicate deliveries (retransmits, double taps).
+    let now = Date()
+    guard now.timeIntervalSince(lastToggleRequestAt) > 1.5 else { return }
+    lastToggleRequestAt = now
+
+    onToggleRequested?(UUID(uuidString: tagProfileId))
+  }
+}

--- a/Foqos/Utils/CompanionDeviceManager.swift
+++ b/Foqos/Utils/CompanionDeviceManager.swift
@@ -2,10 +2,20 @@ import CoreBluetooth
 import SwiftData
 import SwiftUI
 
-// Pushes blocking session status to an ESP32 companion device over BLE and
-// points its NFC tag at a profile deep link. Opt-in: no CBCentralManager (and
+// UserDefaults keys shared between the manager and views that mirror its
+// settings via @AppStorage.
+enum CompanionDeviceDefaults {
+  static let enabledKey = "companionDeviceEnabled"
+  static let identifierKey = "companionDeviceIdentifier"
+  static let nameKey = "companionDeviceName"
+  static let profileIdKey = "companionDeviceProfileId"
+}
+
+// Pushes blocking session status to a companion device over BLE and points
+// its NFC tag at a profile deep link. Opt-in: no CBCentralManager (and
 // therefore no Bluetooth permission prompt) exists until the user enables the
-// feature in settings. GATT contract lives in esp32-companion/README.md.
+// feature in settings. The canonical GATT contract is
+// docs/companion-device-protocol.md.
 class CompanionDeviceManager: NSObject, ObservableObject {
   static let shared = CompanionDeviceManager()
 
@@ -14,20 +24,27 @@ class CompanionDeviceManager: NSObject, ObservableObject {
   static let timeSyncCharacteristicUUID = CBUUID(string: "F0C50003-8B1E-4B6D-9F26-3F0B5C7A1D01")
   static let tagConfigCharacteristicUUID = CBUUID(string: "F0C50004-8B1E-4B6D-9F26-3F0B5C7A1D01")
   static let toggleCharacteristicUUID = CBUUID(string: "F0C50005-8B1E-4B6D-9F26-3F0B5C7A1D01")
+  static let tagURLMaxBytes = 128
   private static let restoreIdentifier = "dev.ambitionsoftware.foqos.companionCentral"
 
-  @AppStorage("companionDeviceEnabled") private(set) var isEnabled: Bool = false
-  @AppStorage("companionDeviceIdentifier") private var pairedIdentifier: String = ""
-  @AppStorage("companionDeviceName") private(set) var pairedDeviceName: String = ""
-  @AppStorage("companionDeviceProfileId") var tagProfileId: String = ""
+  @AppStorage(CompanionDeviceDefaults.enabledKey) private(set) var isEnabled: Bool = false
+  @AppStorage(CompanionDeviceDefaults.identifierKey) private var pairedIdentifier: String = ""
+  @AppStorage(CompanionDeviceDefaults.nameKey) private(set) var pairedDeviceName: String = ""
+  @AppStorage(CompanionDeviceDefaults.profileIdKey) var tagProfileId: String = ""
 
   @Published var isConnected: Bool = false
   @Published var isScanning: Bool = false
   @Published var discoveredPeripherals: [CBPeripheral] = []
+  @Published var bluetoothState: CBManagerState = .unknown
 
   // Fired when the device asks to toggle the session (e.g. a screen tap),
   // passing the profile configured for the device's tag. Wired in foqosApp.
   var onToggleRequested: ((UUID?) -> Void)?
+
+  // Fired after each (re)connection so the app pushes current truth with
+  // fresh stats — the device may have rebooted and lost its RAM state, and
+  // the cached payload may be stale. Wired in foqosApp.
+  var onStatusRefreshNeeded: (() -> Void)?
 
   private var centralManager: CBCentralManager?
   private var connectedPeripheral: CBPeripheral?
@@ -43,6 +60,12 @@ class CompanionDeviceManager: NSObject, ObservableObject {
   private var pendingTagConfigURL: String?
   private var wantsScanning = false
   private var lastToggleRequestAt: Date = .distantPast
+  private var lastToggleCounter: UInt8?
+
+  // Writes in flight, so a failure re-queues its value instead of the device
+  // silently keeping stale state, and a second flush can't double-write.
+  private var inFlightStatusWrite = false
+  private var inFlightTagConfigURL: String?
 
   var isPaired: Bool {
     return !pairedIdentifier.isEmpty
@@ -108,10 +131,18 @@ class CompanionDeviceManager: NSObject, ObservableObject {
     guard isEnabled, isPaired else { return }
 
     var payload = makePayload(for: session)
-    let stats = CompanionStatsCalculator.stats(in: context)
-    payload.streakDays = UInt16(clamping: stats.streakDays)
-    payload.todayFocusSeconds = UInt32(clamping: stats.todayFocusSeconds)
-    payload.weekMinutes = stats.weekMinutes.map { UInt16(clamping: $0) }
+    if connectedPeripheral?.state == .connected || currentStatus == nil {
+      let stats = CompanionStatsCalculator.stats(in: context)
+      payload.streakDays = UInt16(clamping: stats.streakDays)
+      payload.todayFocusSeconds = UInt32(clamping: stats.todayFocusSeconds)
+      payload.weekMinutes = stats.weekMinutes.map { UInt16(clamping: $0) }
+    } else if let previous = currentStatus {
+      // Nothing is listening, so skip the year-long session fetch; the
+      // reconnect flow re-pushes via onStatusRefreshNeeded with fresh stats.
+      payload.streakDays = previous.streakDays
+      payload.todayFocusSeconds = previous.todayFocusSeconds
+      payload.weekMinutes = previous.weekMinutes
+    }
 
     if payload == currentStatus && !statusDirty { return }
     currentStatus = payload
@@ -125,8 +156,21 @@ class CompanionDeviceManager: NSObject, ObservableObject {
 
   func pushTagConfig(profile: BlockedProfiles) {
     guard isEnabled, isPaired else { return }
+    let url = BlockedProfiles.getProfileDeepLink(profile)
+    // The protocol caps tag URLs at 128 bytes; generated deep links are far
+    // shorter, and a truncated URL would be worse than no write.
+    guard url.utf8.count <= Self.tagURLMaxBytes else { return }
     tagProfileId = profile.id.uuidString
-    pendingTagConfigURL = BlockedProfiles.getProfileDeepLink(profile)
+    pendingTagConfigURL = url
+    flushPendingWrites()
+  }
+
+  // Clears the device's NFC tag (a zero-length tag-config write, per the
+  // protocol doc) and forgets the configured profile.
+  func clearTagConfig() {
+    guard isEnabled, isPaired else { return }
+    tagProfileId = ""
+    pendingTagConfigURL = ""
     flushPendingWrites()
   }
 
@@ -186,11 +230,20 @@ class CompanionDeviceManager: NSObject, ObservableObject {
     if let peripheral = connectedPeripheral {
       centralManager?.cancelPeripheralConnection(peripheral)
     }
+    clearPeripheralState()
+  }
+
+  // Drops all references to the current peripheral without cancelling the
+  // connection; used when iOS has already invalidated it.
+  private func clearPeripheralState() {
     connectedPeripheral = nil
     statusCharacteristic = nil
     timeSyncCharacteristic = nil
     tagConfigCharacteristic = nil
+    inFlightStatusWrite = false
+    inFlightTagConfigURL = nil
     isConnected = false
+    isScanning = false
   }
 
   private func flushPendingWrites() {
@@ -199,16 +252,21 @@ class CompanionDeviceManager: NSObject, ObservableObject {
       return
     }
 
-    if statusDirty, let status = currentStatus, let characteristic = statusCharacteristic {
-      peripheral.writeValue(status.encoded(), for: characteristic, type: .withResponse)
+    if statusDirty, !inFlightStatusWrite, let status = currentStatus,
+      let characteristic = statusCharacteristic
+    {
+      inFlightStatusWrite = true
       statusDirty = false
+      peripheral.writeValue(status.encoded(), for: characteristic, type: .withResponse)
     }
 
-    if let url = pendingTagConfigURL, let characteristic = tagConfigCharacteristic,
+    if let url = pendingTagConfigURL, inFlightTagConfigURL == nil,
+      let characteristic = tagConfigCharacteristic,
       let data = url.data(using: .utf8)
     {
-      peripheral.writeValue(data, for: characteristic, type: .withResponse)
+      inFlightTagConfigURL = url
       pendingTagConfigURL = nil
+      peripheral.writeValue(data, for: characteristic, type: .withResponse)
     }
   }
 
@@ -224,6 +282,7 @@ class CompanionDeviceManager: NSObject, ObservableObject {
 
 extension CompanionDeviceManager: CBCentralManagerDelegate {
   func centralManagerDidUpdateState(_ central: CBCentralManager) {
+    bluetoothState = central.state
     switch central.state {
     case .poweredOn:
       scanIfPoweredOn()
@@ -235,6 +294,11 @@ extension CompanionDeviceManager: CBCentralManagerDelegate {
       } else {
         reconnectPairedPeripheral()
       }
+    case .poweredOff, .resetting, .unauthorized:
+      // iOS invalidates peripherals here without firing
+      // didDisconnectPeripheral; a stale connectedPeripheral would block
+      // reconnectPairedPeripheral forever once Bluetooth comes back.
+      clearPeripheralState()
     default:
       isConnected = false
     }
@@ -278,6 +342,8 @@ extension CompanionDeviceManager: CBCentralManagerDelegate {
     statusCharacteristic = nil
     timeSyncCharacteristic = nil
     tagConfigCharacteristic = nil
+    inFlightStatusWrite = false
+    inFlightTagConfigURL = nil
 
     // Re-issue the connect so iOS delivers the device when it reappears.
     if isEnabled, isPaired {
@@ -336,10 +402,43 @@ extension CompanionDeviceManager: CBPeripheralDelegate {
     }
 
     // The device has no RTC: sync the wall clock, then re-push the current
-    // truth (the device may have rebooted since the last write).
+    // truth (the device may have rebooted since the last write). The cached
+    // payload goes out immediately; onStatusRefreshNeeded follows up with a
+    // freshly computed one, coalesced away when nothing changed.
     writeTimeSync(to: peripheral)
     statusDirty = currentStatus != nil
     flushPendingWrites()
+    onStatusRefreshNeeded?()
+  }
+
+  func peripheral(
+    _ peripheral: CBPeripheral,
+    didWriteValueFor characteristic: CBCharacteristic,
+    error: Error?
+  ) {
+    switch characteristic.uuid {
+    case Self.statusCharacteristicUUID:
+      inFlightStatusWrite = false
+      if error != nil {
+        // Re-queue instead of letting the device keep stale state; the next
+        // lifecycle push or reconnect delivers it.
+        statusDirty = true
+      } else if statusDirty {
+        // A newer payload arrived while this write was in flight.
+        flushPendingWrites()
+      }
+    case Self.tagConfigCharacteristicUUID:
+      let attempted = inFlightTagConfigURL
+      inFlightTagConfigURL = nil
+      if error != nil {
+        // Keep a newer pending URL if one superseded the failed write.
+        pendingTagConfigURL = pendingTagConfigURL ?? attempted
+      } else if pendingTagConfigURL != nil {
+        flushPendingWrites()
+      }
+    default:
+      break
+    }
   }
 
   func peripheral(
@@ -349,11 +448,32 @@ extension CompanionDeviceManager: CBPeripheralDelegate {
   ) {
     guard characteristic.uuid == Self.toggleCharacteristicUUID, error == nil else { return }
 
-    // Debounce duplicate deliveries (retransmits, double taps).
     let now = Date()
-    guard now.timeIntervalSince(lastToggleRequestAt) > 1.5 else { return }
+    let counter = characteristic.value?.first
+    guard
+      Self.shouldAcceptToggle(
+        counter: counter, at: now, lastAcceptedAt: lastToggleRequestAt,
+        lastCounter: lastToggleCounter)
+    else { return }
     lastToggleRequestAt = now
+    lastToggleCounter = counter
 
     onToggleRequested?(UUID(uuidString: tagProfileId))
+  }
+
+  // Debounces double taps and drops BLE retransmits (same counter value
+  // shortly after the original). Counters can repeat after a device reboot,
+  // so a match only counts as a duplicate within a short window. Pure so the
+  // documented semantics stay test-locked (CompanionToggleDedupTests).
+  static func shouldAcceptToggle(
+    counter: UInt8?, at now: Date, lastAcceptedAt: Date, lastCounter: UInt8?
+  ) -> Bool {
+    guard now.timeIntervalSince(lastAcceptedAt) > 1.5 else { return false }
+    if let counter = counter, counter == lastCounter,
+      now.timeIntervalSince(lastAcceptedAt) < 30
+    {
+      return false
+    }
+    return true
   }
 }

--- a/Foqos/Utils/CompanionDeviceManager.swift
+++ b/Foqos/Utils/CompanionDeviceManager.swift
@@ -1,4 +1,5 @@
 import CoreBluetooth
+import SwiftData
 import SwiftUI
 
 // Pushes blocking session status to an ESP32 companion device over BLE and
@@ -103,17 +104,23 @@ class CompanionDeviceManager: NSObject, ObservableObject {
 
   // MARK: - Pushes
 
-  func pushStatus(session: BlockedProfileSession?) {
+  func pushStatus(session: BlockedProfileSession?, context: ModelContext) {
     guard isEnabled, isPaired else { return }
-    let payload = makePayload(for: session)
+
+    var payload = makePayload(for: session)
+    let stats = CompanionStatsCalculator.stats(in: context)
+    payload.streakDays = UInt16(clamping: stats.streakDays)
+    payload.todayFocusSeconds = UInt32(clamping: stats.todayFocusSeconds)
+    payload.weekMinutes = stats.weekMinutes.map { UInt16(clamping: $0) }
+
     if payload == currentStatus && !statusDirty { return }
     currentStatus = payload
     statusDirty = true
     flushPendingWrites()
   }
 
-  func pushSessionEnded() {
-    pushStatus(session: nil)
+  func pushSessionEnded(context: ModelContext) {
+    pushStatus(session: nil, context: context)
   }
 
   func pushTagConfig(profile: BlockedProfiles) {

--- a/Foqos/Utils/CompanionStatsCalculator.swift
+++ b/Foqos/Utils/CompanionStatsCalculator.swift
@@ -37,20 +37,24 @@ enum CompanionStatsCalculator {
       calendar: calendar
     )
 
-    var streak = 0
-    for daysAgo in 0..<streakLookbackDays {
-      guard let dayStart = calendar.date(byAdding: .day, value: -daysAgo, to: todayStart),
-        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)
-      else { break }
+    // Pre-bucket every day each interval touches, so the streak walk is a
+    // set lookup instead of scanning all intervals per day.
+    var focusDays = Set<Date>()
+    for interval in intervals {
+      var day = calendar.startOfDay(for: interval.startTime)
+      while day < interval.endTime {
+        focusDays.insert(day)
+        guard let next = calendar.date(byAdding: .day, value: 1, to: day) else { break }
+        day = next
+      }
+    }
 
-      let hasFocus = intervals.contains { interval in
-        interval.startTime < dayEnd && interval.endTime > dayStart
-      }
-      if hasFocus {
-        streak += 1
-      } else {
-        break
-      }
+    var streak = 0
+    var day = todayStart
+    while streak < streakLookbackDays, focusDays.contains(day) {
+      streak += 1
+      guard let previous = calendar.date(byAdding: .day, value: -1, to: day) else { break }
+      day = previous
     }
 
     return CompanionStats(

--- a/Foqos/Utils/CompanionStatsCalculator.swift
+++ b/Foqos/Utils/CompanionStatsCalculator.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SwiftData
+
+struct CompanionStats: Equatable {
+  var streakDays: Int
+  var todayFocusSeconds: Int
+  var weekMinutes: [Int]  // oldest first, [6] = today
+
+  static let zero = CompanionStats(
+    streakDays: 0,
+    todayFocusSeconds: 0,
+    weekMinutes: Array(repeating: 0, count: 7)
+  )
+}
+
+// Computes the stats shown on companion devices. Reuses
+// WeeklySessionAggregator so the device always matches the app's insights,
+// and mirrors ProfileInsightsUtil.currentStreakDays semantics (the streak is
+// anchored to today).
+enum CompanionStatsCalculator {
+  static func stats(
+    for intervals: [WeeklySessionInterval],
+    now: Date = Date(),
+    calendar: Calendar = .current,
+    streakLookbackDays: Int = 365
+  ) -> CompanionStats {
+    guard !intervals.isEmpty else { return .zero }
+
+    let todayStart = calendar.startOfDay(for: now)
+    guard let windowStart = calendar.date(byAdding: .day, value: -6, to: todayStart) else {
+      return .zero
+    }
+
+    let week = WeeklySessionAggregator.aggregate(
+      sessions: intervals,
+      weekStart: windowStart,
+      calendar: calendar
+    )
+
+    var streak = 0
+    for daysAgo in 0..<streakLookbackDays {
+      guard let dayStart = calendar.date(byAdding: .day, value: -daysAgo, to: todayStart),
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)
+      else { break }
+
+      let hasFocus = intervals.contains { interval in
+        interval.startTime < dayEnd && interval.endTime > dayStart
+      }
+      if hasFocus {
+        streak += 1
+      } else {
+        break
+      }
+    }
+
+    return CompanionStats(
+      streakDays: streak,
+      todayFocusSeconds: Int(week.dailyDurations[6]),
+      weekMinutes: week.dailyDurations.map { Int($0 / 60) }
+    )
+  }
+
+  // Fetches recent sessions and computes stats; active sessions count up to
+  // "now" so today's total includes the in-progress session.
+  static func stats(in context: ModelContext, now: Date = Date()) -> CompanionStats {
+    guard let lookbackStart = Calendar.current.date(byAdding: .day, value: -365, to: now) else {
+      return .zero
+    }
+
+    let descriptor = FetchDescriptor<BlockedProfileSession>(
+      predicate: #Predicate { $0.startTime >= lookbackStart }
+    )
+    guard let sessions = try? context.fetch(descriptor) else { return .zero }
+
+    let intervals = sessions.compactMap { session -> WeeklySessionInterval? in
+      let end = session.endTime ?? now
+      guard end > session.startTime else { return nil }
+      return WeeklySessionInterval(startTime: session.startTime, endTime: end)
+    }
+    return stats(for: intervals, now: now)
+  }
+}

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -323,6 +323,15 @@ class StrategyManager: ObservableObject {
     }
   }
 
+  // Re-pushes current truth (session + fresh stats) to the companion device;
+  // called after every BLE (re)connection via onStatusRefreshNeeded.
+  func pushCompanionStatus(context: ModelContext) {
+    companionDeviceManager.pushStatus(
+      session: getActiveSession(context: context),
+      context: context
+    )
+  }
+
   // Toggle requested from the companion device (e.g. a screen tap): stops the
   // active session if one is running, otherwise starts the configured profile.
   func toggleSessionFromCompanion(profileId: UUID?, context: ModelContext) {

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -94,7 +94,7 @@ class StrategyManager: ObservableObject {
 
     // Reconcile the companion device with the current truth, covering
     // sessions started or ended while the app was not running
-    companionDeviceManager.pushStatus(session: activeSession)
+    companionDeviceManager.pushStatus(session: activeSession, context: context)
   }
 
   func toggleBlocking(context: ModelContext, activeProfile: BlockedProfiles?) {
@@ -359,7 +359,7 @@ class StrategyManager: ObservableObject {
 
     // Do end sections for the profile
     self.liveActivityManager.endSessionActivity()
-    self.companionDeviceManager.pushSessionEnded()
+    self.companionDeviceManager.pushSessionEnded(context: context)
     self.scheduleReminder(profile: activeSession.blockedProfile)
     self.stopTimer()
 
@@ -439,9 +439,9 @@ class StrategyManager: ObservableObject {
       case .paused:
         self.handlePauseStarted(context: context)
       case .started(let session):
-        self.handleSessionStarted(session: session)
+        self.handleSessionStarted(session: session, context: context)
       case .ended(let endedProfile):
-        self.handleSessionEnded(profile: endedProfile)
+        self.handleSessionEnded(profile: endedProfile, context: context)
       }
     }
 
@@ -495,7 +495,7 @@ class StrategyManager: ObservableObject {
 
     // Update live activity to show break state
     liveActivityManager.updateBreakState(session: session)
-    companionDeviceManager.pushStatus(session: session)
+    companionDeviceManager.pushStatus(session: session, context: context)
   }
 
   private func stopBreak(context: ModelContext) {
@@ -526,7 +526,7 @@ class StrategyManager: ObservableObject {
 
     // Update live activity to show break has ended
     liveActivityManager.updateBreakState(session: session)
-    companionDeviceManager.pushStatus(session: session)
+    companionDeviceManager.pushStatus(session: session, context: context)
   }
 
   private func handlePauseStarted(context: ModelContext) {
@@ -544,7 +544,7 @@ class StrategyManager: ObservableObject {
     }
   }
 
-  private func handleSessionStarted(session: BlockedProfileSession) {
+  private func handleSessionStarted(session: BlockedProfileSession, context: ModelContext) {
     self.dismissView()
 
     if SoftUnblockGrantStore.activeSession?.sessionId != session.id {
@@ -563,13 +563,13 @@ class StrategyManager: ObservableObject {
     self.startTimer()
     self.liveActivityManager
       .startSessionActivity(session: session)
-    self.companionDeviceManager.pushStatus(session: session)
+    self.companionDeviceManager.pushStatus(session: session, context: context)
 
     // Refresh widgets when session starts
     WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
   }
 
-  private func handleSessionEnded(profile: BlockedProfiles) {
+  private func handleSessionEnded(profile: BlockedProfiles, context: ModelContext) {
     self.dismissView()
 
     SoftUnblockGrantScheduler.stopAll()
@@ -579,7 +579,7 @@ class StrategyManager: ObservableObject {
     self.timersUtil.cancelAll()
     self.activeSession = nil
     self.liveActivityManager.endSessionActivity()
-    self.companionDeviceManager.pushSessionEnded()
+    self.companionDeviceManager.pushSessionEnded(context: context)
     self.scheduleReminder(profile: profile)
 
     self.stopTimer()

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -40,6 +40,7 @@ class StrategyManager: ObservableObject {
     Double = 0
 
   private let liveActivityManager = LiveActivityManager.shared
+  private let companionDeviceManager = CompanionDeviceManager.shared
 
   private let timersUtil = TimersUtil()
   private let appBlocker = AppBlockerUtil()
@@ -90,6 +91,10 @@ class StrategyManager: ObservableObject {
 
     // Reload widget to reflect any changes from extension (e.g., timer expiration)
     WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
+
+    // Reconcile the companion device with the current truth, covering
+    // sessions started or ended while the app was not running
+    companionDeviceManager.pushStatus(session: activeSession)
   }
 
   func toggleBlocking(context: ModelContext, activeProfile: BlockedProfiles?) {
@@ -318,6 +323,18 @@ class StrategyManager: ObservableObject {
     }
   }
 
+  // Toggle requested from the companion device (e.g. a screen tap): stops the
+  // active session if one is running, otherwise starts the configured profile.
+  func toggleSessionFromCompanion(profileId: UUID?, context: ModelContext) {
+    if let activeSession = getActiveSession(context: context) {
+      stopSessionFromBackground(activeSession.blockedProfile.id, context: context)
+    } else if let profileId = profileId {
+      startSessionFromBackground(profileId, context: context)
+    } else {
+      print("companion toggle ignored: no active session and no profile configured")
+    }
+  }
+
   func getRemainingEmergencyUnblocks() -> Int {
     return emergencyUnblocksRemaining
   }
@@ -342,6 +359,7 @@ class StrategyManager: ObservableObject {
 
     // Do end sections for the profile
     self.liveActivityManager.endSessionActivity()
+    self.companionDeviceManager.pushSessionEnded()
     self.scheduleReminder(profile: activeSession.blockedProfile)
     self.stopTimer()
 
@@ -477,6 +495,7 @@ class StrategyManager: ObservableObject {
 
     // Update live activity to show break state
     liveActivityManager.updateBreakState(session: session)
+    companionDeviceManager.pushStatus(session: session)
   }
 
   private func stopBreak(context: ModelContext) {
@@ -507,6 +526,7 @@ class StrategyManager: ObservableObject {
 
     // Update live activity to show break has ended
     liveActivityManager.updateBreakState(session: session)
+    companionDeviceManager.pushStatus(session: session)
   }
 
   private func handlePauseStarted(context: ModelContext) {
@@ -543,6 +563,7 @@ class StrategyManager: ObservableObject {
     self.startTimer()
     self.liveActivityManager
       .startSessionActivity(session: session)
+    self.companionDeviceManager.pushStatus(session: session)
 
     // Refresh widgets when session starts
     WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
@@ -558,6 +579,7 @@ class StrategyManager: ObservableObject {
     self.timersUtil.cancelAll()
     self.activeSession = nil
     self.liveActivityManager.endSessionActivity()
+    self.companionDeviceManager.pushSessionEnded()
     self.scheduleReminder(profile: profile)
 
     self.stopTimer()

--- a/Foqos/Views/CompanionDeviceView.swift
+++ b/Foqos/Views/CompanionDeviceView.swift
@@ -1,0 +1,182 @@
+import SwiftData
+import SwiftUI
+
+let companionFirmwareLink = "https://github.com/rachelworld/foqos-companion"
+
+struct CompanionDeviceView: View {
+  @Environment(\.dismiss) private var dismiss
+  @EnvironmentObject var themeManager: ThemeManager
+  @EnvironmentObject var companionDeviceManager: CompanionDeviceManager
+
+  @Query(sort: \BlockedProfiles.order) private var profiles: [BlockedProfiles]
+
+  // Mirrored from CompanionDeviceManager so the view re-renders on changes.
+  @AppStorage("companionDeviceEnabled") private var isEnabled: Bool = false
+  @AppStorage("companionDeviceIdentifier") private var pairedIdentifier: String = ""
+  @AppStorage("companionDeviceName") private var pairedDeviceName: String = ""
+  @AppStorage("companionDeviceProfileId") private var tagProfileId: String = ""
+
+  @State private var showUnpairAlert = false
+
+  private var isPaired: Bool {
+    return !pairedIdentifier.isEmpty
+  }
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        Section {
+          HStack {
+            Image(systemName: "sensor.tag.radiowaves.forward.fill")
+              .foregroundStyle(themeManager.themeColor)
+              .font(.title3)
+
+            VStack(alignment: .leading, spacing: 2) {
+              Text("Companion Device")
+                .font(.headline)
+              Text(
+                "Show live session status on an ESP32 device and toggle sessions with its NFC tag"
+              )
+              .font(.caption)
+              .foregroundStyle(.secondary)
+            }
+          }
+          .padding(.vertical, 8)
+
+          Toggle("Enable Companion Device", isOn: $isEnabled)
+            .onChange(of: isEnabled) { _, enabled in
+              companionDeviceManager.setEnabled(enabled)
+            }
+        }
+
+        if isEnabled {
+          if isPaired {
+            pairedSection
+          } else {
+            scanningSection
+          }
+        }
+
+        Section {
+          Link(destination: URL(string: companionFirmwareLink)!) {
+            HStack {
+              Text("Build Your Own Device")
+                .foregroundColor(.primary)
+              Spacer()
+              Image(systemName: "arrow.up.right.square")
+                .foregroundColor(.secondary)
+            }
+          }
+        }
+      }
+      .navigationTitle("Companion Device")
+      .toolbar {
+        ToolbarItem(placement: .topBarLeading) {
+          Button(action: { dismiss() }) {
+            Image(systemName: "xmark")
+          }
+          .accessibilityLabel("Close")
+        }
+      }
+      .alert("Unpair Device", isPresented: $showUnpairAlert) {
+        Button("Cancel", role: .cancel) {}
+        Button("Unpair", role: .destructive) {
+          companionDeviceManager.unpair()
+        }
+      } message: {
+        Text("The device will stop receiving session updates until paired again.")
+      }
+      .onDisappear {
+        companionDeviceManager.stopScanning()
+      }
+    }
+  }
+
+  private var pairedSection: some View {
+    Section("Device") {
+      HStack {
+        Text(pairedDeviceName.isEmpty ? "Foqos Companion" : pairedDeviceName)
+          .foregroundStyle(.primary)
+        Spacer()
+        HStack(spacing: 8) {
+          Circle()
+            .fill(companionDeviceManager.isConnected ? .green : .red)
+            .frame(width: 8, height: 8)
+          Text(companionDeviceManager.isConnected ? "Connected" : "Not Connected")
+            .foregroundStyle(.secondary)
+            .font(.subheadline)
+        }
+      }
+
+      Picker("Device Profile", selection: $tagProfileId) {
+        Text("None").tag("")
+        ForEach(profiles, id: \.id) { profile in
+          Text(profile.name).tag(profile.id.uuidString)
+        }
+      }
+      .onChange(of: tagProfileId) { _, newValue in
+        writeTagProfile(id: newValue)
+      }
+
+      Button {
+        writeTagProfile(id: tagProfileId)
+      } label: {
+        Text("Write Tag to Device")
+          .foregroundColor(themeManager.themeColor)
+      }
+      .disabled(tagProfileId.isEmpty || !companionDeviceManager.isConnected)
+
+      Button {
+        showUnpairAlert = true
+      } label: {
+        Text("Unpair Device")
+          .foregroundColor(.red)
+      }
+    }
+  }
+
+  private var scanningSection: some View {
+    Section("Nearby Devices") {
+      if companionDeviceManager.discoveredPeripherals.isEmpty {
+        HStack {
+          ProgressView()
+          Text("Searching for devices...")
+            .foregroundStyle(.secondary)
+            .padding(.leading, 8)
+        }
+        .onAppear {
+          companionDeviceManager.startScanning()
+        }
+      }
+
+      ForEach(companionDeviceManager.discoveredPeripherals, id: \.identifier) { peripheral in
+        Button {
+          companionDeviceManager.pair(peripheral)
+        } label: {
+          HStack {
+            Text(peripheral.name ?? "Unknown Device")
+              .foregroundColor(.primary)
+            Spacer()
+            Image(systemName: "link")
+              .foregroundColor(.secondary)
+              .font(.caption)
+          }
+        }
+      }
+    }
+  }
+
+  private func writeTagProfile(id: String) {
+    guard let uuid = UUID(uuidString: id),
+      let profile = profiles.first(where: { $0.id == uuid })
+    else { return }
+    companionDeviceManager.pushTagConfig(profile: profile)
+  }
+}
+
+#Preview {
+  CompanionDeviceView()
+    .environmentObject(ThemeManager.shared)
+    .environmentObject(CompanionDeviceManager.shared)
+    .modelContainer(for: BlockedProfiles.self, inMemory: true)
+}

--- a/Foqos/Views/CompanionDeviceView.swift
+++ b/Foqos/Views/CompanionDeviceView.swift
@@ -2,6 +2,8 @@ import CoreBluetooth
 import SwiftData
 import SwiftUI
 
+let companionFirmwareLink = "https://github.com/rachelworld/foqos-companion"
+
 struct CompanionDeviceView: View {
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject var themeManager: ThemeManager
@@ -16,6 +18,7 @@ struct CompanionDeviceView: View {
   @AppStorage(CompanionDeviceDefaults.profileIdKey) private var tagProfileId: String = ""
 
   @State private var showUnpairAlert = false
+  @State private var searchTimedOut = false
 
   private var isPaired: Bool {
     return !pairedIdentifier.isEmpty
@@ -163,11 +166,34 @@ struct CompanionDeviceView: View {
           .foregroundStyle(.secondary)
           .font(.subheadline)
       } else if companionDeviceManager.discoveredPeripherals.isEmpty {
-        HStack {
-          ProgressView()
-          Text("Searching for devices...")
+        if searchTimedOut {
+          // Most users have no companion hardware: turn the dead-end into
+          // an explanation and a pointer, while scanning continues quietly.
+          VStack(alignment: .leading, spacing: 8) {
+            Label("No companion devices found nearby", systemImage: "magnifyingglass")
+              .foregroundStyle(.secondary)
+              .font(.subheadline)
+            Text(
+              "A companion device is DIY hardware that shows your focus status on your desk."
+            )
+            .font(.caption)
             .foregroundStyle(.secondary)
-            .padding(.leading, 8)
+            Link(destination: URL(string: companionFirmwareLink)!) {
+              HStack(spacing: 4) {
+                Text("Learn how to build one")
+                Image(systemName: "arrow.up.right.square")
+              }
+              .font(.caption)
+            }
+          }
+          .padding(.vertical, 4)
+        } else {
+          HStack {
+            ProgressView()
+            Text("Searching for devices...")
+              .foregroundStyle(.secondary)
+              .padding(.leading, 8)
+          }
         }
       }
 
@@ -191,6 +217,13 @@ struct CompanionDeviceView: View {
     // sheet would otherwise never rescan.
     .onAppear {
       companionDeviceManager.startScanning()
+    }
+    .task {
+      searchTimedOut = false
+      try? await Task.sleep(nanoseconds: 12_000_000_000)
+      if !Task.isCancelled {
+        searchTimedOut = true
+      }
     }
   }
 

--- a/Foqos/Views/CompanionDeviceView.swift
+++ b/Foqos/Views/CompanionDeviceView.swift
@@ -1,7 +1,6 @@
+import CoreBluetooth
 import SwiftData
 import SwiftUI
-
-let companionFirmwareLink = "https://github.com/rachelworld/foqos-companion"
 
 struct CompanionDeviceView: View {
   @Environment(\.dismiss) private var dismiss
@@ -11,10 +10,10 @@ struct CompanionDeviceView: View {
   @Query(sort: \BlockedProfiles.order) private var profiles: [BlockedProfiles]
 
   // Mirrored from CompanionDeviceManager so the view re-renders on changes.
-  @AppStorage("companionDeviceEnabled") private var isEnabled: Bool = false
-  @AppStorage("companionDeviceIdentifier") private var pairedIdentifier: String = ""
-  @AppStorage("companionDeviceName") private var pairedDeviceName: String = ""
-  @AppStorage("companionDeviceProfileId") private var tagProfileId: String = ""
+  @AppStorage(CompanionDeviceDefaults.enabledKey) private var isEnabled: Bool = false
+  @AppStorage(CompanionDeviceDefaults.identifierKey) private var pairedIdentifier: String = ""
+  @AppStorage(CompanionDeviceDefaults.nameKey) private var pairedDeviceName: String = ""
+  @AppStorage(CompanionDeviceDefaults.profileIdKey) private var tagProfileId: String = ""
 
   @State private var showUnpairAlert = false
 
@@ -35,7 +34,7 @@ struct CompanionDeviceView: View {
               Text("Companion Device")
                 .font(.headline)
               Text(
-                "Show live session status on an ESP32 device and toggle sessions with its NFC tag"
+                "Show live session status on a companion device and toggle sessions with its NFC tag"
               )
               .font(.caption)
               .foregroundStyle(.secondary)
@@ -54,18 +53,6 @@ struct CompanionDeviceView: View {
             pairedSection
           } else {
             scanningSection
-          }
-        }
-
-        Section {
-          Link(destination: URL(string: companionFirmwareLink)!) {
-            HStack {
-              Text("Build Your Own Device")
-                .foregroundColor(.primary)
-              Spacer()
-              Image(systemName: "arrow.up.right.square")
-                .foregroundColor(.secondary)
-            }
           }
         }
       }
@@ -102,7 +89,7 @@ struct CompanionDeviceView: View {
           Circle()
             .fill(companionDeviceManager.isConnected ? .green : .red)
             .frame(width: 8, height: 8)
-          Text(companionDeviceManager.isConnected ? "Connected" : "Not Connected")
+          Text(connectionStatusText)
             .foregroundStyle(.secondary)
             .font(.subheadline)
         }
@@ -115,7 +102,11 @@ struct CompanionDeviceView: View {
         }
       }
       .onChange(of: tagProfileId) { _, newValue in
-        writeTagProfile(id: newValue)
+        if newValue.isEmpty {
+          companionDeviceManager.clearTagConfig()
+        } else {
+          writeTagProfile(id: newValue)
+        }
       }
 
       Button {
@@ -135,17 +126,48 @@ struct CompanionDeviceView: View {
     }
   }
 
+  // User-actionable explanation for why scanning or reconnecting can't work
+  // right now; nil when Bluetooth is usable.
+  private var bluetoothProblem: String? {
+    switch companionDeviceManager.bluetoothState {
+    case .poweredOff:
+      return "Bluetooth is turned off. Turn it on to connect to your device."
+    case .unauthorized:
+      return "Foqos doesn't have Bluetooth access. "
+        + "Allow it in Settings > Privacy & Security > Bluetooth."
+    case .unsupported:
+      return "Bluetooth is not available on this device."
+    default:
+      return nil
+    }
+  }
+
+  private var connectionStatusText: String {
+    if companionDeviceManager.isConnected {
+      return "Connected"
+    }
+    switch companionDeviceManager.bluetoothState {
+    case .poweredOff:
+      return "Bluetooth Off"
+    case .unauthorized:
+      return "No Bluetooth Access"
+    default:
+      return "Not Connected"
+    }
+  }
+
   private var scanningSection: some View {
     Section("Nearby Devices") {
-      if companionDeviceManager.discoveredPeripherals.isEmpty {
+      if let problem = bluetoothProblem {
+        Label(problem, systemImage: "exclamationmark.triangle")
+          .foregroundStyle(.secondary)
+          .font(.subheadline)
+      } else if companionDeviceManager.discoveredPeripherals.isEmpty {
         HStack {
           ProgressView()
           Text("Searching for devices...")
             .foregroundStyle(.secondary)
             .padding(.leading, 8)
-        }
-        .onAppear {
-          companionDeviceManager.startScanning()
         }
       }
 
@@ -163,6 +185,12 @@ struct CompanionDeviceView: View {
           }
         }
       }
+    }
+    // On the section, not the placeholder row: the row never reappears once
+    // a stale discovery survives in the shared manager, so reopening the
+    // sheet would otherwise never rescan.
+    .onAppear {
+      companionDeviceManager.startScanning()
     }
   }
 

--- a/Foqos/Views/SettingsView.swift
+++ b/Foqos/Views/SettingsView.swift
@@ -60,7 +60,7 @@ struct SettingsView: View {
 
         AppIconPicker(selectionColor: themeManager.themeColor)
 
-        Section("Companion Device") {
+        Section("Devices") {
           HStack {
             Text("Companion Device")
               .foregroundColor(.primary)

--- a/Foqos/Views/SettingsView.swift
+++ b/Foqos/Views/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
 
   @State private var showResetBlockingStateAlert = false
   @State private var showDebugView = false
+  @State private var showCompanionDeviceView = false
 
   private var appVersion: String {
     Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
@@ -58,6 +59,20 @@ struct SettingsView: View {
         }
 
         AppIconPicker(selectionColor: themeManager.themeColor)
+
+        Section("Companion Device") {
+          HStack {
+            Text("Companion Device")
+              .foregroundColor(.primary)
+            Spacer()
+            Image(systemName: "chevron.right")
+              .foregroundColor(.secondary)
+              .font(.caption)
+          }
+          .onTapGesture {
+            showCompanionDeviceView = true
+          }
+        }
 
         Section("Help") {
           HStack {
@@ -180,6 +195,9 @@ struct SettingsView: View {
       }
       .sheet(isPresented: $showDebugView) {
         DebugView()
+      }
+      .sheet(isPresented: $showCompanionDeviceView) {
+        CompanionDeviceView()
       }
     }
   }

--- a/Foqos/foqosApp.swift
+++ b/Foqos/foqosApp.swift
@@ -40,9 +40,23 @@ struct foqosApp: App {
   @StateObject private var liveActivityManager = LiveActivityManager.shared
   @StateObject private var themeManager = ThemeManager.shared
   @StateObject private var alertsManager = AlertsManager.shared
+  @StateObject private var companionDeviceManager = CompanionDeviceManager.shared
 
   init() {
     TimersUtil.registerBackgroundTasks()
+
+    // Must run at launch (not onAppear) so CoreBluetooth state restoration
+    // can re-adopt the companion device when iOS relaunches the app in the
+    // background for a BLE event.
+    CompanionDeviceManager.shared.start()
+    CompanionDeviceManager.shared.onToggleRequested = { profileId in
+      Task { @MainActor in
+        StrategyManager.shared.toggleSessionFromCompanion(
+          profileId: profileId,
+          context: container.mainContext
+        )
+      }
+    }
 
     let asyncDependency: @Sendable () async -> (ModelContainer) = {
       @MainActor in
@@ -77,6 +91,7 @@ struct foqosApp: App {
         .environmentObject(ratingManager)
         .environmentObject(liveActivityManager)
         .environmentObject(themeManager)
+        .environmentObject(companionDeviceManager)
     }
     .modelContainer(container)
   }

--- a/Foqos/foqosApp.swift
+++ b/Foqos/foqosApp.swift
@@ -57,6 +57,11 @@ struct foqosApp: App {
         )
       }
     }
+    CompanionDeviceManager.shared.onStatusRefreshNeeded = {
+      Task { @MainActor in
+        StrategyManager.shared.pushCompanionStatus(context: container.mainContext)
+      }
+    }
 
     let asyncDependency: @Sendable () async -> (ModelContainer) = {
       @MainActor in

--- a/docs/companion-device-protocol.md
+++ b/docs/companion-device-protocol.md
@@ -6,9 +6,10 @@ over Bluetooth LE and accept session toggle requests from it. The feature is
 Bluetooth permission prompt appears) until the user enables it in
 Settings → Companion Device.
 
-Any hardware that implements the peripheral side of this contract works. A
-reference open-source implementation (ESP32 + AMOLED display + NFC tag) lives
-at <https://github.com/rachelworld/foqos-companion>.
+Any hardware that implements the peripheral side of this contract works —
+e.g. a microcontroller with a display, optionally carrying an NFC tag. This
+document is the canonical contract; firmware implementations live outside
+this repository.
 
 ## Roles
 
@@ -31,8 +32,8 @@ F0C50001-8B1E-4B6D-9F26-3F0B5C7A1D01
 | --- | --- | --- | --- |
 | Status | `…0002` | app → device (write) | packed status, below |
 | Time sync | `…0003` | app → device (write) | `i64` current epoch seconds, LE; written on every connect (device may lack an RTC) |
-| Tag config | `…0004` | app → device (write) | UTF-8 profile deep-link URL (≤128 B) for devices carrying an NFC tag |
-| Toggle | `…0005` | device → app (notify) | `u8` monotonic counter; each notification asks the app to toggle the session |
+| Tag config | `…0004` | app → device (write) | UTF-8 profile deep-link URL (≤128 B) for devices carrying an NFC tag; a zero-length write clears the tag |
+| Toggle | `…0005` | device → app (notify) | `u8` monotonic counter; each notification asks the app to toggle the session. The app uses the counter to drop retransmits, so devices should increment it per tap |
 
 ## Status payload (little-endian, fixed offsets)
 
@@ -49,8 +50,16 @@ Version 2, 102 bytes:
 | 84 | `u32` | today's focus time, seconds |
 | 88 | `u16[7]` | focus minutes per day, oldest first, `[6]` = today |
 
-Version 1 is the same layout truncated at 82 bytes; devices should accept both
-and treat missing stats as zero.
+Version 1 is the same layout truncated at 82 bytes.
+
+### Versioning
+
+The payload is append-only: a new version only adds fields after the existing
+ones and bumps the version byte; existing offsets never change. Devices MUST
+accept any version greater than or equal to the one they were built for,
+parse the prefix they understand, and treat fields beyond the received length
+as zero. A parser that requires an exact version match breaks on the next
+release.
 
 ## Behavioral contract
 
@@ -64,10 +73,24 @@ and treat missing stats as zero.
   treat RAM state as disposable.
 - Toggle semantics: active session → stop (subject to the profile's
   `disableBackgroundStops`); no session → start the profile the user selected
-  in the companion settings. The app debounces duplicate notifications
-  delivered within 1.5 s.
+  in the companion settings. The app debounces notifications delivered within
+  1.5 s and drops repeats of the last counter value within 30 s.
 - Toggle requests are fire-and-forget; devices should show a pending state and
   revert after ~10 s if no confirming status write arrives.
+
+## Security
+
+The link is deliberately unauthenticated and unencrypted. BLE
+bonding/pairing is out of scope: the payload carries no secrets (session
+flags, epochs, a profile name, aggregate focus stats), and requiring bonding
+would exclude hobbyist hardware without persistent key storage. Anyone in
+radio range can read status writes or send toggle notifications; the blast
+radius is bounded because toggle requests go through the same path as in-app
+actions — a profile with `disableBackgroundStops` ignores stop requests, so a
+nearby attacker cannot break a locked focus commitment. The worst case is
+starting a session, or stopping one whose profile already allows background
+stops. Implementations that want more can layer BLE bonding on the same GATT
+service without changing this contract.
 
 ## Swift surface (for maintainers)
 
@@ -75,4 +98,4 @@ and treat missing stats as zero.
 (Models) is the pure, unit-tested encoder; `StrategyManager` calls
 `pushStatus`/`pushSessionEnded` at its existing lifecycle points, mirroring
 `LiveActivityManager`. Payload byte layout is locked by golden-vector tests
-shared with the reference firmware (`foqosTests/CompanionStatusPayloadTests`).
+(`foqosTests/CompanionStatusPayloadTests`) that firmware decoders can share.

--- a/docs/companion-device-protocol.md
+++ b/docs/companion-device-protocol.md
@@ -1,0 +1,78 @@
+# Companion Device Protocol
+
+Foqos can push live blocking-session status to an external "companion device"
+over Bluetooth LE and accept session toggle requests from it. The feature is
+**opt-in and dormant by default**: no `CBCentralManager` is created (and no
+Bluetooth permission prompt appears) until the user enables it in
+Settings → Companion Device.
+
+Any hardware that implements the peripheral side of this contract works. A
+reference open-source implementation (ESP32 + AMOLED display + NFC tag) lives
+at <https://github.com/rachelworld/foqos-companion>.
+
+## Roles
+
+- **Foqos (iOS)**: BLE central. Connects, writes status, subscribes to toggle
+  requests. Uses CoreBluetooth state restoration so reconnection and toggle
+  handling survive backgrounding.
+- **Companion device**: BLE peripheral. Advertises the service below, renders
+  status, optionally sends toggle requests (e.g. from a button or touch
+  screen).
+
+## GATT service
+
+Device name: `Foqos Companion` (advertised). Service UUID:
+
+```
+F0C50001-8B1E-4B6D-9F26-3F0B5C7A1D01
+```
+
+| Characteristic | UUID (`F0C5000x-…`) | Direction | Payload |
+| --- | --- | --- | --- |
+| Status | `…0002` | app → device (write) | packed status, below |
+| Time sync | `…0003` | app → device (write) | `i64` current epoch seconds, LE; written on every connect (device may lack an RTC) |
+| Tag config | `…0004` | app → device (write) | UTF-8 profile deep-link URL (≤128 B) for devices carrying an NFC tag |
+| Toggle | `…0005` | device → app (notify) | `u8` monotonic counter; each notification asks the app to toggle the session |
+
+## Status payload (little-endian, fixed offsets)
+
+Version 2, 102 bytes:
+
+| Offset | Type | Field |
+| --- | --- | --- |
+| 0 | `u8` | version (= 2) |
+| 1 | `u8` | flags: bit0 active, bit1 break, bit2 pause |
+| 2 | `i64` | session start, epoch seconds (0 = none) |
+| 10 | `i64` | expected end, epoch seconds (0 = open-ended) |
+| 18 | `u8[64]` | profile name, UTF-8, null-padded, truncated at a scalar boundary |
+| 82 | `u16` | focus streak, days |
+| 84 | `u32` | today's focus time, seconds |
+| 88 | `u16[7]` | focus minutes per day, oldest first, `[6]` = today |
+
+Version 1 is the same layout truncated at 82 bytes; devices should accept both
+and treat missing stats as zero.
+
+## Behavioral contract
+
+- The app writes status **on session state changes** (start/stop/break/pause),
+  on reconnect, and on app foreground — not continuously. Devices with timers
+  must count down/up locally from the epochs plus the time-sync value.
+- Timer expiry is **not** pushed in real time (iOS may not be running);
+  devices flip to inactive locally when `expectedEndEpoch` passes and
+  reconcile on the next write.
+- The app re-pushes current status after every (re)connection; devices may
+  treat RAM state as disposable.
+- Toggle semantics: active session → stop (subject to the profile's
+  `disableBackgroundStops`); no session → start the profile the user selected
+  in the companion settings. The app debounces duplicate notifications
+  delivered within 1.5 s.
+- Toggle requests are fire-and-forget; devices should show a pending state and
+  revert after ~10 s if no confirming status write arrives.
+
+## Swift surface (for maintainers)
+
+`CompanionDeviceManager` (Utils) owns the BLE session; `CompanionStatusPayload`
+(Models) is the pure, unit-tested encoder; `StrategyManager` calls
+`pushStatus`/`pushSessionEnded` at its existing lifecycle points, mirroring
+`LiveActivityManager`. Payload byte layout is locked by golden-vector tests
+shared with the reference firmware (`foqosTests/CompanionStatusPayloadTests`).

--- a/foqos.xcodeproj/project.pbxproj
+++ b/foqos.xcodeproj/project.pbxproj
@@ -938,6 +938,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Foqos;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NFCReaderUsageDescription = "This app uses NFC to scan tags for item identification.";
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Foqos connects to your companion device to show blocking status.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "We need camera access to scan QR codes to active/deactivate profiles";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -992,6 +993,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Foqos;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NFCReaderUsageDescription = "This app uses NFC to scan tags for item identification.";
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Foqos connects to your companion device to show blocking status.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "We need camera access to scan QR codes to active/deactivate profiles";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;

--- a/foqosTests/CompanionStatsCalculatorTests.swift
+++ b/foqosTests/CompanionStatsCalculatorTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+
+@testable import foqos
+
+final class CompanionStatsCalculatorTests: XCTestCase {
+  private var calendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "UTC")!
+    return calendar
+  }
+
+  // Fixed "now": 2026-07-15 14:00 UTC
+  private var now: Date {
+    DateComponents(
+      calendar: calendar, year: 2026, month: 7, day: 15, hour: 14
+    ).date!
+  }
+
+  private func interval(daysAgo: Int, hour: Int, minutes: Int) -> WeeklySessionInterval {
+    let start = calendar.date(
+      byAdding: .day, value: -daysAgo,
+      to: DateComponents(calendar: calendar, year: 2026, month: 7, day: 15, hour: hour).date!
+    )!
+    return WeeklySessionInterval(
+      startTime: start, endTime: start.addingTimeInterval(TimeInterval(minutes * 60)))
+  }
+
+  func testEmptySessionsProduceZeroStats() {
+    let stats = CompanionStatsCalculator.stats(for: [], now: now, calendar: calendar)
+    XCTAssertEqual(stats, .zero)
+    XCTAssertEqual(stats.weekMinutes.count, 7)
+  }
+
+  func testTodayTotalAndWeekBuckets() {
+    let stats = CompanionStatsCalculator.stats(
+      for: [
+        interval(daysAgo: 0, hour: 9, minutes: 30),
+        interval(daysAgo: 0, hour: 11, minutes: 15),
+        interval(daysAgo: 2, hour: 10, minutes: 60),
+        interval(daysAgo: 6, hour: 10, minutes: 45),
+        interval(daysAgo: 8, hour: 10, minutes: 90),  // outside the week window
+      ],
+      now: now, calendar: calendar
+    )
+
+    XCTAssertEqual(stats.todayFocusSeconds, 45 * 60)
+    XCTAssertEqual(stats.weekMinutes, [45, 0, 0, 0, 60, 0, 45])
+  }
+
+  func testStreakCountsConsecutiveDaysEndingToday() {
+    let stats = CompanionStatsCalculator.stats(
+      for: [
+        interval(daysAgo: 0, hour: 9, minutes: 10),
+        interval(daysAgo: 1, hour: 9, minutes: 10),
+        interval(daysAgo: 2, hour: 9, minutes: 10),
+        interval(daysAgo: 4, hour: 9, minutes: 10),  // gap at day 3 ends the streak
+      ],
+      now: now, calendar: calendar
+    )
+    XCTAssertEqual(stats.streakDays, 3)
+  }
+
+  func testNoSessionTodayMeansZeroStreak() {
+    // Matches ProfileInsightsUtil.currentStreakDays: the streak is anchored
+    // to today, so a day without focus (so far) shows 0.
+    let stats = CompanionStatsCalculator.stats(
+      for: [interval(daysAgo: 1, hour: 9, minutes: 30)],
+      now: now, calendar: calendar
+    )
+    XCTAssertEqual(stats.streakDays, 0)
+  }
+
+  func testOvernightSessionSplitsAcrossDaysAndExtendsStreak() {
+    // 23:30 yesterday -> 00:30 today: 30 minutes in each bucket, both days count.
+    let start = calendar.date(
+      byAdding: .minute, value: 30,
+      to: DateComponents(calendar: calendar, year: 2026, month: 7, day: 14, hour: 23).date!
+    )!
+    let stats = CompanionStatsCalculator.stats(
+      for: [WeeklySessionInterval(startTime: start, endTime: start.addingTimeInterval(3600))],
+      now: now, calendar: calendar
+    )
+
+    XCTAssertEqual(stats.weekMinutes[6], 30)  // today
+    XCTAssertEqual(stats.weekMinutes[5], 30)  // yesterday
+    XCTAssertEqual(stats.todayFocusSeconds, 30 * 60)
+    XCTAssertEqual(stats.streakDays, 2)
+  }
+}

--- a/foqosTests/CompanionStatusPayloadTests.swift
+++ b/foqosTests/CompanionStatusPayloadTests.swift
@@ -3,17 +3,23 @@ import XCTest
 @testable import foqos
 
 final class CompanionStatusPayloadTests: XCTestCase {
-  // Golden payload shared byte-for-byte with the firmware decoder tests
-  // (esp32-companion/test/test_status_model/test_main.cpp).
+  // Golden v2 payload shared byte-for-byte with the firmware decoder tests
+  // (foqos-companion repo, test/test_status_model/test_main.cpp).
   private var goldenBytes: [UInt8] {
     var bytes: [UInt8] = [
-      0x01,  // version
+      0x02,  // version
       0x01,  // flags: active
       0x00, 0xCA, 0x9A, 0x3B, 0, 0, 0, 0,  // start epoch 1000000000 LE
       0x58, 0xCC, 0x9A, 0x3B, 0, 0, 0, 0,  // end epoch 1000000600 LE
     ]
     bytes.append(contentsOf: Array("Work".utf8))
     bytes.append(contentsOf: [UInt8](repeating: 0, count: 64 - 4))
+    bytes.append(contentsOf: [12, 0])  // streak 12 LE
+    bytes.append(contentsOf: [0x08, 0x34, 0, 0])  // today 13320s LE
+    for minutes in [30, 60, 0, 45, 90, 120, 222] as [UInt16] {
+      bytes.append(UInt8(minutes & 0xFF))
+      bytes.append(UInt8(minutes >> 8))
+    }
     return bytes
   }
 
@@ -24,10 +30,27 @@ final class CompanionStatusPayloadTests: XCTestCase {
       isPauseActive: false,
       sessionStartEpoch: 1_000_000_000,
       expectedEndEpoch: 1_000_000_600,
-      profileName: "Work"
+      profileName: "Work",
+      streakDays: 12,
+      todayFocusSeconds: 13320,
+      weekMinutes: [30, 60, 0, 45, 90, 120, 222]
     )
 
     XCTAssertEqual([UInt8](payload.encoded()), goldenBytes)
+  }
+
+  func testStatsDefaultToZero() {
+    let bytes = [UInt8](CompanionStatusPayload.inactive.encoded())
+    XCTAssertEqual(bytes.count, CompanionStatusPayload.encodedSize)
+    XCTAssertTrue(bytes[82...].allSatisfy { $0 == 0 })
+  }
+
+  func testWeekMinutesPadsAndTruncatesToSevenEntries() {
+    var payload = CompanionStatusPayload.inactive
+    payload.weekMinutes = [1, 2]  // short: pads with zeros
+    XCTAssertEqual(payload.encoded().count, CompanionStatusPayload.encodedSize)
+    payload.weekMinutes = Array(repeating: 9, count: 12)  // long: truncates
+    XCTAssertEqual(payload.encoded().count, CompanionStatusPayload.encodedSize)
   }
 
   func testEncodedSizeIsAlwaysFixed() {
@@ -45,7 +68,7 @@ final class CompanionStatusPayloadTests: XCTestCase {
     for payload in payloads {
       XCTAssertEqual(payload.encoded().count, CompanionStatusPayload.encodedSize)
     }
-    XCTAssertEqual(CompanionStatusPayload.encodedSize, 82)
+    XCTAssertEqual(CompanionStatusPayload.encodedSize, 102)
   }
 
   func testFlagCombinations() {
@@ -71,7 +94,7 @@ final class CompanionStatusPayloadTests: XCTestCase {
 
   func testInactivePayloadIsAllZerosAfterVersion() {
     let bytes = [UInt8](CompanionStatusPayload.inactive.encoded())
-    XCTAssertEqual(bytes[0], 1)
+    XCTAssertEqual(bytes[0], 2)
     XCTAssertTrue(bytes.dropFirst().allSatisfy { $0 == 0 })
   }
 
@@ -89,7 +112,7 @@ final class CompanionStatusPayloadTests: XCTestCase {
     )
 
     let bytes = [UInt8](payload.encoded())
-    let nameField = Array(bytes[18...])
+    let nameField = Array(bytes[18..<82])
     XCTAssertEqual(nameField.count, 64)
     XCTAssertEqual(nameField[62], UInt8(ascii: "a"))
     // The é must be dropped entirely, not half-written.
@@ -110,8 +133,8 @@ final class CompanionStatusPayloadTests: XCTestCase {
     )
 
     let bytes = [UInt8](payload.encoded())
-    XCTAssertEqual(bytes.count, 82)
-    XCTAssertTrue(bytes[18...].allSatisfy { $0 == UInt8(ascii: "x") })
+    XCTAssertEqual(bytes.count, 102)
+    XCTAssertTrue(bytes[18..<82].allSatisfy { $0 == UInt8(ascii: "x") })
   }
 
   func testNegativeEpochsRoundTripAsLittleEndianTwosComplement() {

--- a/foqosTests/CompanionStatusPayloadTests.swift
+++ b/foqosTests/CompanionStatusPayloadTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+
+@testable import foqos
+
+final class CompanionStatusPayloadTests: XCTestCase {
+  // Golden payload shared byte-for-byte with the firmware decoder tests
+  // (esp32-companion/test/test_status_model/test_main.cpp).
+  private var goldenBytes: [UInt8] {
+    var bytes: [UInt8] = [
+      0x01,  // version
+      0x01,  // flags: active
+      0x00, 0xCA, 0x9A, 0x3B, 0, 0, 0, 0,  // start epoch 1000000000 LE
+      0x58, 0xCC, 0x9A, 0x3B, 0, 0, 0, 0,  // end epoch 1000000600 LE
+    ]
+    bytes.append(contentsOf: Array("Work".utf8))
+    bytes.append(contentsOf: [UInt8](repeating: 0, count: 64 - 4))
+    return bytes
+  }
+
+  func testEncodedLayoutMatchesGoldenVector() {
+    let payload = CompanionStatusPayload(
+      isActive: true,
+      isBreakActive: false,
+      isPauseActive: false,
+      sessionStartEpoch: 1_000_000_000,
+      expectedEndEpoch: 1_000_000_600,
+      profileName: "Work"
+    )
+
+    XCTAssertEqual([UInt8](payload.encoded()), goldenBytes)
+  }
+
+  func testEncodedSizeIsAlwaysFixed() {
+    let payloads = [
+      CompanionStatusPayload.inactive,
+      CompanionStatusPayload(
+        isActive: true,
+        isBreakActive: true,
+        isPauseActive: true,
+        sessionStartEpoch: .max,
+        expectedEndEpoch: .max,
+        profileName: String(repeating: "long", count: 100)
+      ),
+    ]
+    for payload in payloads {
+      XCTAssertEqual(payload.encoded().count, CompanionStatusPayload.encodedSize)
+    }
+    XCTAssertEqual(CompanionStatusPayload.encodedSize, 82)
+  }
+
+  func testFlagCombinations() {
+    let combos: [(Bool, Bool, Bool, UInt8)] = [
+      (false, false, false, 0b000),
+      (true, false, false, 0b001),
+      (true, true, false, 0b011),
+      (true, false, true, 0b101),
+      (true, true, true, 0b111),
+    ]
+    for (active, breakActive, pauseActive, expectedFlags) in combos {
+      let payload = CompanionStatusPayload(
+        isActive: active,
+        isBreakActive: breakActive,
+        isPauseActive: pauseActive,
+        sessionStartEpoch: 0,
+        expectedEndEpoch: 0,
+        profileName: ""
+      )
+      XCTAssertEqual([UInt8](payload.encoded())[1], expectedFlags)
+    }
+  }
+
+  func testInactivePayloadIsAllZerosAfterVersion() {
+    let bytes = [UInt8](CompanionStatusPayload.inactive.encoded())
+    XCTAssertEqual(bytes[0], 1)
+    XCTAssertTrue(bytes.dropFirst().allSatisfy { $0 == 0 })
+  }
+
+  func testNameTruncationDoesNotSplitMultibyteCharacter() {
+    // 63 ASCII bytes followed by a 2-byte scalar: truncating at 64 bytes
+    // blindly would leave a dangling UTF-8 continuation byte.
+    let name = String(repeating: "a", count: 63) + "é"
+    let payload = CompanionStatusPayload(
+      isActive: true,
+      isBreakActive: false,
+      isPauseActive: false,
+      sessionStartEpoch: 0,
+      expectedEndEpoch: 0,
+      profileName: name
+    )
+
+    let bytes = [UInt8](payload.encoded())
+    let nameField = Array(bytes[18...])
+    XCTAssertEqual(nameField.count, 64)
+    XCTAssertEqual(nameField[62], UInt8(ascii: "a"))
+    // The é must be dropped entirely, not half-written.
+    XCTAssertEqual(nameField[63], 0)
+
+    let decoded = String(decoding: nameField.prefix(while: { $0 != 0 }), as: UTF8.self)
+    XCTAssertEqual(decoded, String(repeating: "a", count: 63))
+  }
+
+  func testLongNameTruncatesToSixtyFourBytes() {
+    let payload = CompanionStatusPayload(
+      isActive: true,
+      isBreakActive: false,
+      isPauseActive: false,
+      sessionStartEpoch: 0,
+      expectedEndEpoch: 0,
+      profileName: String(repeating: "x", count: 200)
+    )
+
+    let bytes = [UInt8](payload.encoded())
+    XCTAssertEqual(bytes.count, 82)
+    XCTAssertTrue(bytes[18...].allSatisfy { $0 == UInt8(ascii: "x") })
+  }
+
+  func testNegativeEpochsRoundTripAsLittleEndianTwosComplement() {
+    let payload = CompanionStatusPayload(
+      isActive: true,
+      isBreakActive: false,
+      isPauseActive: false,
+      sessionStartEpoch: -1,
+      expectedEndEpoch: Int64.min,
+      profileName: ""
+    )
+
+    let bytes = [UInt8](payload.encoded())
+    XCTAssertTrue(bytes[2...9].allSatisfy { $0 == 0xFF })
+    XCTAssertEqual(Array(bytes[10...16]), [UInt8](repeating: 0, count: 7))
+    XCTAssertEqual(bytes[17], 0x80)
+  }
+}

--- a/foqosTests/CompanionToggleDedupTests.swift
+++ b/foqosTests/CompanionToggleDedupTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import foqos
+
+// Locks the toggle dedup semantics documented in
+// docs/companion-device-protocol.md: 1.5 s debounce, and same-counter
+// retransmits dropped within 30 s (counters can repeat after device reboots).
+final class CompanionToggleDedupTests: XCTestCase {
+  private let epoch = Date(timeIntervalSinceReferenceDate: 1_000)
+
+  private func accepts(
+    counter: UInt8?, secondsAfterLast: TimeInterval, lastCounter: UInt8?
+  ) -> Bool {
+    CompanionDeviceManager.shouldAcceptToggle(
+      counter: counter,
+      at: epoch.addingTimeInterval(secondsAfterLast),
+      lastAcceptedAt: epoch,
+      lastCounter: lastCounter
+    )
+  }
+
+  func testRejectsRapidDoubleTapRegardlessOfCounter() {
+    XCTAssertFalse(accepts(counter: 5, secondsAfterLast: 1.0, lastCounter: 4))
+    XCTAssertFalse(accepts(counter: nil, secondsAfterLast: 0.2, lastCounter: nil))
+  }
+
+  func testRejectsSameCounterRetransmitWithinWindow() {
+    XCTAssertFalse(accepts(counter: 7, secondsAfterLast: 10, lastCounter: 7))
+    XCTAssertFalse(accepts(counter: 7, secondsAfterLast: 29.9, lastCounter: 7))
+  }
+
+  func testAcceptsSameCounterAfterWindowExpires() {
+    // A rebooted device restarts its counter; a match after 30 s is a new tap.
+    XCTAssertTrue(accepts(counter: 7, secondsAfterLast: 30.1, lastCounter: 7))
+  }
+
+  func testAcceptsNewCounterAfterDebounce() {
+    XCTAssertTrue(accepts(counter: 8, secondsAfterLast: 2.0, lastCounter: 7))
+  }
+
+  func testAcceptsMissingCounterAfterDebounce() {
+    // Devices that send no counter byte still get the time debounce only.
+    XCTAssertTrue(accepts(counter: nil, secondsAfterLast: 2.0, lastCounter: nil))
+  }
+}


### PR DESCRIPTION
Hi @awaseem — thanks for building and open-sourcing Foqos. It's been a huge help for my studies, so much so I created this desktop companion device to mirror the app and keep me focused. While ESP32 community is starting to grow, I made this PR optional for those who don't have the device. But I'm very happy to trim scope, split this up, or adjust anything to match how you'd like the codebase to evolve. And no hard feelings if this isn't the direction you'd like to go. Just let me know either way as I'll keep maintaining the firmware repo against the documented protocol either way.

<p align="center">
  <img src="https://raw.githubusercontent.com/rachelworld/foqos-companion/main/docs/images/foqos_on.jpg" alt="Foqos Companion showing the focus orb, screen on" width="420">
  <img src="https://raw.githubusercontent.com/rachelworld/foqos-companion/main/docs/images/foqos_off.jpg" alt="Foqos Companion display off" width="420">
</p>

## Summary of changes

- **Dormant by default.** No `CBCentralManager` is created and **no Bluetooth permission prompt appears** until the user explicitly enables the feature in Settings → Companion Device.
- **Zero runtime cost when off.** Stats and status payloads are only computed *after* the enabled/paired guard — disabled means no work, no allocations, no BLE.
- **No new third-party dependencies.** CoreBluetooth only; nothing added to the package graph.
- **Nothing removed or rewritten.** Existing flows are untouched; status pushes hook the *existing* `StrategyManager` lifecycle points, mirroring how `LiveActivityManager` already works.

If a user never toggles it on, the app behaves exactly as it does today.

## What it does (when enabled)

- **Ambient status display** while focusing, plus an idle stats card showing today's focus total, a 7‑day heatmap, and streak — always in sync with the app's own insights.
- **Tap to toggle** a blocking session on the phone over Bluetooth LE (respects `disableBackgroundStops`).
- **Optional NFC tag** on the device to toggle via the existing profile deep link, even with BLE unpaired.
- Local-first, matching Foqos's philosophy: one BLE link to the phone, **no Wi‑Fi, no cloud, no accounts.**

## How it fits the existing architecture

- `CompanionDeviceManager` — CoreBluetooth central with state restoration, auto‑reconnect, and coalesced status writes.
- `CompanionStatusPayload` — a pure, unit-tested packed encoder. Golden vectors are shared byte-for-byte with the reference firmware.
- `CompanionStatsCalculator` — **reuses** `WeeklySessionAggregator` and mirrors `ProfileInsightsUtil` streak semantics, so the device always shows the same numbers as the app.
- Status pushes reuse existing `StrategyManager` lifecycle hooks (same pattern as `LiveActivityManager`).
- Protocol is fully documented in `docs/companion-device-protocol.md`, including **append-only versioning rules** so older firmware and newer app builds stay compatible (v1 devices safely ignore the v2 stats trailer).

## Testing

- `CompanionStatusPayloadTests` — golden-vector encoding, byte-for-byte.
- `CompanionStatsCalculatorTests` — stats/streak semantics.
- `CompanionToggleDedupTests` — the debounce/dedup logic extracted as a pure, test-locked function.

## The firmware lives in a separate repo — no extra burden on you

The hardware/firmware is an independent MIT-licensed project I maintain: https://github.com/rachelworld/foqos-companion. This PR only adds the **app-side protocol** and an opt-in Settings surface. You don't take on any hardware maintenance, and the empty-state UI simply points curious users to that repo rather than promising hardware.

## Commits (reviewable in order)

1. **Add companion device support over Bluetooth LE** — core feature.
2. **Send focus stats to companion devices (payload v2)** — append-only stats trailer.
3. **Harden companion device reliability and address review findings** — robustness pass (in-flight write re-queue, BLE state surfacing, reconnect re-push, dedup test-lock).
4. **Explain the empty state when no companion device is found** — graceful dead-end for the majority who have no hardware.

