### PR TITLE
Add pause active session shortcut

### DIFF
--- a/Foqos/Intents/PauseActiveSessionError.swift
+++ b/Foqos/Intents/PauseActiveSessionError.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum PauseActiveSessionError: LocalizedError, Equatable {
+  case noActiveSession
+  case unsupportedStrategy(profileName: String)
+  case alreadyPaused(profileName: String)
+  case breakActive(profileName: String)
+  case missingPauseConfiguration(profileName: String)
+  case schedulingFailed(profileName: String, reason: String)
+
+  var errorDescription: String? {
+    switch self {
+    case .noActiveSession:
+      return "No active Foqos session to pause."
+    case .unsupportedStrategy(let profileName):
+      return "\(profileName) does not use a strategy that supports pausing."
+    case .alreadyPaused(let profileName):
+      return "\(profileName) is already paused."
+    case .breakActive(let profileName):
+      return "End the active break before pausing \(profileName)."
+    case .missingPauseConfiguration(let profileName):
+      return "\(profileName) does not have a pause duration configured."
+    case .schedulingFailed(let profileName, let reason):
+      return "Could not pause \(profileName): \(reason)"
+    }
+  }
+}

--- a/Foqos/Intents/PauseActiveSessionIntent.swift
+++ b/Foqos/Intents/PauseActiveSessionIntent.swift
@@ -1,0 +1,28 @@
+import AppIntents
+import SwiftData
+
+struct PauseActiveSessionIntent: AppIntent {
+  @Dependency(key: "ModelContainer")
+  private var modelContainer: ModelContainer
+
+  @MainActor
+  private var modelContext: ModelContext {
+    return modelContainer.mainContext
+  }
+
+  static var title: LocalizedStringResource = "Pause Active Foqos Session"
+  static var description = IntentDescription(
+    "Pause the currently active Foqos session when its strategy supports pausing."
+  )
+
+  static var openAppWhenRun: Bool = false
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    let profileName = try StrategyManager.shared.pauseActiveSessionFromBackground(
+      context: modelContext
+    )
+
+    return .result(dialog: "Paused profile: \(profileName)")
+  }
+}

--- a/Foqos/Utils/DeviceActivityCenterUtil.swift
+++ b/Foqos/Utils/DeviceActivityCenterUtil.swift
@@ -4,6 +4,10 @@ import ManagedSettings
 import SwiftUI
 
 class DeviceActivityCenterUtil {
+  enum PauseTimerSchedulingError: Error {
+    case missingConfiguration
+  }
+
   static func scheduleTimerActivity(for profile: BlockedProfiles) {
     // Only schedule if the schedule is active
     guard let schedule = profile.schedule else { return }
@@ -134,9 +138,16 @@ class DeviceActivityCenterUtil {
   }
 
   static func startPauseTimerActivity(for profile: BlockedProfiles) {
+    do {
+      try schedulePauseTimerActivity(for: profile)
+    } catch {
+      print("Failed to start pause timer activity: \(error.localizedDescription)")
+    }
+  }
+
+  static func schedulePauseTimerActivity(for profile: BlockedProfiles) throws {
     guard let strategyData = profile.strategyData else {
-      print("No strategy data found for pause timer")
-      return
+      throw PauseTimerSchedulingError.missingConfiguration
     }
     let pauseData = StrategyPauseTimerData.toStrategyPauseTimerData(from: strategyData)
 
@@ -154,13 +165,9 @@ class DeviceActivityCenterUtil {
       repeats: false,
     )
 
-    do {
-      stopActivities(for: [deviceActivityName], with: center)
-      try center.startMonitoring(deviceActivityName, during: deviceActivitySchedule)
-      print("Scheduled pause timer activity from \(intervalStart) to \(intervalEnd)")
-    } catch {
-      print("Failed to start pause timer activity: \(error.localizedDescription)")
-    }
+    stopActivities(for: [deviceActivityName], with: center)
+    try center.startMonitoring(deviceActivityName, during: deviceActivitySchedule)
+    print("Scheduled pause timer activity from \(intervalStart) to \(intervalEnd)")
   }
 
   static func removePauseTimerActivity(for profile: BlockedProfiles) {

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -266,6 +266,51 @@ class StrategyManager: ObservableObject {
     }
   }
 
+  func pauseActiveSessionFromBackground(
+    context: ModelContext,
+    schedulePause: (BlockedProfiles) throws -> Void =
+      DeviceActivityCenterUtil.schedulePauseTimerActivity
+  ) throws -> String {
+    guard let session = getActiveSession(context: context) else {
+      throw PauseActiveSessionError.noActiveSession
+    }
+
+    let profile = session.blockedProfile
+    let profileName = profile.name
+    let strategy = StrategyManager.availableStrategies.first {
+      $0.getIdentifier() == session.tag
+    }
+
+    guard strategy?.hasPauseMode == true else {
+      throw PauseActiveSessionError.unsupportedStrategy(profileName: profileName)
+    }
+
+    guard !session.isPauseActive else {
+      throw PauseActiveSessionError.alreadyPaused(profileName: profileName)
+    }
+
+    guard !session.isBreakActive else {
+      throw PauseActiveSessionError.breakActive(profileName: profileName)
+    }
+
+    guard profile.strategyData != nil else {
+      throw PauseActiveSessionError.missingPauseConfiguration(profileName: profileName)
+    }
+
+    do {
+      try schedulePause(profile)
+    } catch DeviceActivityCenterUtil.PauseTimerSchedulingError.missingConfiguration {
+      throw PauseActiveSessionError.missingPauseConfiguration(profileName: profileName)
+    } catch {
+      throw PauseActiveSessionError.schedulingFailed(
+        profileName: profileName,
+        reason: error.localizedDescription
+      )
+    }
+
+    return profileName
+  }
+
   func stopSessionFromBackground(
     _ profileId: UUID,
     context: ModelContext

--- a/foqosTests/PauseActiveSessionTests.swift
+++ b/foqosTests/PauseActiveSessionTests.swift
@@ -1,0 +1,227 @@
+import SwiftData
+import XCTest
+
+@testable import foqos
+
+@MainActor
+final class PauseActiveSessionTests: XCTestCase {
+  private enum SchedulerError: LocalizedError {
+    case unavailable
+
+    var errorDescription: String? {
+      return "Device Activity is unavailable"
+    }
+  }
+
+  override func setUp() {
+    super.setUp()
+    SharedData.flushActiveSession()
+  }
+
+  override func tearDown() {
+    SharedData.flushActiveSession()
+    super.tearDown()
+  }
+
+  func testNFCPauseStrategySchedulesPause() throws {
+    let context = try makeContext()
+    let profile = try makeActiveSession(
+      strategyId: NFCPauseTimerBlockingStrategy.id,
+      context: context
+    ).blockedProfile
+    var scheduledProfileId: UUID?
+
+    let profileName = try StrategyManager().pauseActiveSessionFromBackground(
+      context: context,
+      schedulePause: { scheduledProfileId = $0.id }
+    )
+
+    XCTAssertEqual(profileName, profile.name)
+    XCTAssertEqual(scheduledProfileId, profile.id)
+  }
+
+  func testQRPauseStrategySchedulesPause() throws {
+    let context = try makeContext()
+    let profile = try makeActiveSession(
+      strategyId: QRPauseTimerBlockingStrategy.id,
+      context: context
+    ).blockedProfile
+    var scheduledProfileId: UUID?
+
+    let profileName = try StrategyManager().pauseActiveSessionFromBackground(
+      context: context,
+      schedulePause: { scheduledProfileId = $0.id }
+    )
+
+    XCTAssertEqual(profileName, profile.name)
+    XCTAssertEqual(scheduledProfileId, profile.id)
+  }
+
+  func testNoActiveSessionThrows() throws {
+    let context = try makeContext()
+    var didSchedule = false
+
+    XCTAssertThrowsError(
+      try StrategyManager().pauseActiveSessionFromBackground(
+        context: context,
+        schedulePause: { _ in didSchedule = true }
+      )
+    ) { error in
+      XCTAssertEqual(error as? PauseActiveSessionError, .noActiveSession)
+    }
+    XCTAssertFalse(didSchedule)
+  }
+
+  func testUnsupportedStrategiesThrow() throws {
+    let unsupportedStrategyIds = [
+      ManualBlockingStrategy.id,
+      NFCTimerBlockingStrategy.id,
+      UUID().uuidString,
+    ]
+
+    for strategyId in unsupportedStrategyIds {
+      SharedData.flushActiveSession()
+      let context = try makeContext()
+      _ = try makeActiveSession(strategyId: strategyId, context: context)
+
+      XCTAssertThrowsError(
+        try StrategyManager().pauseActiveSessionFromBackground(
+          context: context,
+          schedulePause: { _ in XCTFail("Pause should not be scheduled") }
+        )
+      ) { error in
+        XCTAssertEqual(
+          error as? PauseActiveSessionError,
+          .unsupportedStrategy(profileName: "Focus")
+        )
+      }
+    }
+  }
+
+  func testAlreadyPausedSessionThrows() throws {
+    let context = try makeContext()
+    let session = try makeActiveSession(
+      strategyId: NFCPauseTimerBlockingStrategy.id,
+      context: context
+    )
+    session.startPause()
+    try context.save()
+
+    XCTAssertThrowsError(
+      try StrategyManager().pauseActiveSessionFromBackground(
+        context: context,
+        schedulePause: { _ in XCTFail("Pause should not be scheduled") }
+      )
+    ) { error in
+      XCTAssertEqual(
+        error as? PauseActiveSessionError,
+        .alreadyPaused(profileName: "Focus")
+      )
+    }
+  }
+
+  func testActiveBreakThrows() throws {
+    let context = try makeContext()
+    let session = try makeActiveSession(
+      strategyId: NFCPauseTimerBlockingStrategy.id,
+      enableBreaks: true,
+      context: context
+    )
+    session.startBreak()
+    try context.save()
+
+    XCTAssertThrowsError(
+      try StrategyManager().pauseActiveSessionFromBackground(
+        context: context,
+        schedulePause: { _ in XCTFail("Pause should not be scheduled") }
+      )
+    ) { error in
+      XCTAssertEqual(
+        error as? PauseActiveSessionError,
+        .breakActive(profileName: "Focus")
+      )
+    }
+  }
+
+  func testMissingPauseConfigurationThrows() throws {
+    let context = try makeContext()
+    _ = try makeActiveSession(
+      strategyId: NFCPauseTimerBlockingStrategy.id,
+      includePauseConfiguration: false,
+      context: context
+    )
+
+    XCTAssertThrowsError(
+      try StrategyManager().pauseActiveSessionFromBackground(
+        context: context,
+        schedulePause: { _ in XCTFail("Pause should not be scheduled") }
+      )
+    ) { error in
+      XCTAssertEqual(
+        error as? PauseActiveSessionError,
+        .missingPauseConfiguration(profileName: "Focus")
+      )
+    }
+  }
+
+  func testSchedulerFailureThrowsLocalizedError() throws {
+    let context = try makeContext()
+    _ = try makeActiveSession(
+      strategyId: NFCPauseTimerBlockingStrategy.id,
+      context: context
+    )
+
+    XCTAssertThrowsError(
+      try StrategyManager().pauseActiveSessionFromBackground(
+        context: context,
+        schedulePause: { _ in throw SchedulerError.unavailable }
+      )
+    ) { error in
+      XCTAssertEqual(
+        error as? PauseActiveSessionError,
+        .schedulingFailed(
+          profileName: "Focus",
+          reason: "Device Activity is unavailable"
+        )
+      )
+    }
+  }
+
+  private func makeContext() throws -> ModelContext {
+    let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+      for: BlockedProfileSession.self,
+      BlockedProfiles.self,
+      configurations: configuration
+    )
+    return ModelContext(container)
+  }
+
+  private func makeActiveSession(
+    strategyId: String,
+    includePauseConfiguration: Bool = true,
+    enableBreaks: Bool = false,
+    context: ModelContext
+  ) throws -> BlockedProfileSession {
+    let strategyData =
+      includePauseConfiguration
+      ? StrategyPauseTimerData.toData(
+        from: StrategyPauseTimerData(pauseDurationInMinutes: 15)
+      ) : nil
+    let profile = BlockedProfiles(
+      name: "Focus",
+      blockingStrategyId: strategyId,
+      strategyData: strategyData,
+      enableBreaks: enableBreaks
+    )
+    context.insert(profile)
+
+    let session = BlockedProfileSession.createSession(
+      in: context,
+      withTag: strategyId,
+      withProfile: profile
+    )
+    try context.save()
+    return session
+  }
+}


### PR DESCRIPTION
Adds a Shortcuts action to pause the active session for pause-capable strategies, with clear errors for unsupported states.

Validation: `make test`, `make build`

Closes #300