### PR TITLE
Default missing pause duration to 15 minutes

### DIFF
--- a/Foqos/Intents/PauseActiveSessionError.swift
+++ b/Foqos/Intents/PauseActiveSessionError.swift
@@ -5,7 +5,6 @@ enum PauseActiveSessionError: LocalizedError, Equatable {
   case unsupportedStrategy(profileName: String)
   case alreadyPaused(profileName: String)
   case breakActive(profileName: String)
-  case missingPauseConfiguration(profileName: String)
   case schedulingFailed(profileName: String, reason: String)
 
   var errorDescription: String? {
@@ -18,8 +17,6 @@ enum PauseActiveSessionError: LocalizedError, Equatable {
       return "\(profileName) is already paused."
     case .breakActive(let profileName):
       return "End the active break before pausing \(profileName)."
-    case .missingPauseConfiguration(let profileName):
-      return "\(profileName) does not have a pause duration configured."
     case .schedulingFailed(let profileName, let reason):
       return "Could not pause \(profileName): \(reason)"
     }

--- a/Foqos/Models/Strategies/Data/StrategyPauseTimerData.swift
+++ b/Foqos/Models/Strategies/Data/StrategyPauseTimerData.swift
@@ -1,13 +1,23 @@
 import SwiftUI
 
 struct StrategyPauseTimerData: Codable {
+  static let defaultPauseDurationInMinutes = 15
+
   var pauseDurationInMinutes: Int
 
-  static func toStrategyPauseTimerData(from data: Data) -> StrategyPauseTimerData {
+  static func toStrategyPauseTimerData(from data: Data?) -> StrategyPauseTimerData {
+    guard let data else {
+      return StrategyPauseTimerData(
+        pauseDurationInMinutes: defaultPauseDurationInMinutes
+      )
+    }
+
     do {
       return try JSONDecoder().decode(StrategyPauseTimerData.self, from: data)
     } catch {
-      return StrategyPauseTimerData(pauseDurationInMinutes: 15)
+      return StrategyPauseTimerData(
+        pauseDurationInMinutes: defaultPauseDurationInMinutes
+      )
     }
   }
 

--- a/Foqos/Utils/DeviceActivityCenterUtil.swift
+++ b/Foqos/Utils/DeviceActivityCenterUtil.swift
@@ -4,10 +4,6 @@ import ManagedSettings
 import SwiftUI
 
 class DeviceActivityCenterUtil {
-  enum PauseTimerSchedulingError: Error {
-    case missingConfiguration
-  }
-
   static func scheduleTimerActivity(for profile: BlockedProfiles) {
     // Only schedule if the schedule is active
     guard let schedule = profile.schedule else { return }
@@ -146,10 +142,7 @@ class DeviceActivityCenterUtil {
   }
 
   static func schedulePauseTimerActivity(for profile: BlockedProfiles) throws {
-    guard let strategyData = profile.strategyData else {
-      throw PauseTimerSchedulingError.missingConfiguration
-    }
-    let pauseData = StrategyPauseTimerData.toStrategyPauseTimerData(from: strategyData)
+    let pauseData = StrategyPauseTimerData.toStrategyPauseTimerData(from: profile.strategyData)
 
     let center = DeviceActivityCenter()
     let pauseTimerActivity = PauseTimerActivity()

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -293,14 +293,8 @@ class StrategyManager: ObservableObject {
       throw PauseActiveSessionError.breakActive(profileName: profileName)
     }
 
-    guard profile.strategyData != nil else {
-      throw PauseActiveSessionError.missingPauseConfiguration(profileName: profileName)
-    }
-
     do {
       try schedulePause(profile)
-    } catch DeviceActivityCenterUtil.PauseTimerSchedulingError.missingConfiguration {
-      throw PauseActiveSessionError.missingPauseConfiguration(profileName: profileName)
     } catch {
       throw PauseActiveSessionError.schedulingFailed(
         profileName: profileName,

--- a/foqosTests/PauseActiveSessionTests.swift
+++ b/foqosTests/PauseActiveSessionTests.swift
@@ -143,25 +143,29 @@ final class PauseActiveSessionTests: XCTestCase {
     }
   }
 
-  func testMissingPauseConfigurationThrows() throws {
+  func testMissingPauseConfigurationUsesDefaultDuration() throws {
     let context = try makeContext()
-    _ = try makeActiveSession(
+    let profile = try makeActiveSession(
       strategyId: NFCPauseTimerBlockingStrategy.id,
       includePauseConfiguration: false,
       context: context
+    ).blockedProfile
+    var scheduledProfileId: UUID?
+
+    let profileName = try StrategyManager().pauseActiveSessionFromBackground(
+      context: context,
+      schedulePause: { scheduledProfileId = $0.id }
+    )
+    let pauseData = StrategyPauseTimerData.toStrategyPauseTimerData(
+      from: profile.strategyData
     )
 
-    XCTAssertThrowsError(
-      try StrategyManager().pauseActiveSessionFromBackground(
-        context: context,
-        schedulePause: { _ in XCTFail("Pause should not be scheduled") }
-      )
-    ) { error in
-      XCTAssertEqual(
-        error as? PauseActiveSessionError,
-        .missingPauseConfiguration(profileName: "Focus")
-      )
-    }
+    XCTAssertEqual(profileName, profile.name)
+    XCTAssertEqual(scheduledProfileId, profile.id)
+    XCTAssertEqual(
+      pauseData.pauseDurationInMinutes,
+      StrategyPauseTimerData.defaultPauseDurationInMinutes
+    )
   }
 
   func testSchedulerFailureThrowsLocalizedError() throws {


### PR DESCRIPTION
Defaults missing NFC/QR pause configuration to 15 minutes so profiles first started through Shortcuts can still be paused instead of silently failing. This removes the obsolete missing-configuration error path, updates regression coverage, and fixes #437; all `PauseActiveSessionTests` and swift-format lint pass.