### PR TITLE
Update Mac filter after Sparkle releases

### DIFF
--- a/FoqosMac/FoqosFilterManager.swift
+++ b/FoqosMac/FoqosFilterManager.swift
@@ -24,7 +24,9 @@ final class FoqosFilterManager: NSObject, ObservableObject {
     category: "filter-manager"
   )
   private var configurationObserver: NSObjectProtocol?
+  private var activationRequest: OSSystemExtensionRequest?
   private var inspectionRequest: OSSystemExtensionRequest?
+  private var isBundledExtensionActive = false
   private var latestRules: FilterRules?
   private var isSavingRules = false
 
@@ -73,6 +75,11 @@ final class FoqosFilterManager: NSObject, ObservableObject {
   }
 
   func installAndEnable() {
+    guard activationRequest == nil else {
+      return
+    }
+
+    isBundledExtensionActive = false
     status = .installing
 
     let request = OSSystemExtensionRequest.activationRequest(
@@ -80,6 +87,7 @@ final class FoqosFilterManager: NSObject, ObservableObject {
       queue: .main
     )
     request.delegate = self
+    activationRequest = request
     OSSystemExtensionManager.shared.submitRequest(request)
   }
 
@@ -108,6 +116,10 @@ final class FoqosFilterManager: NSObject, ObservableObject {
   }
 
   func refreshStatus() {
+    guard isBundledExtensionActive else {
+      return
+    }
+
     NEFilterManager.shared().loadFromPreferences { [weak self] error in
       DispatchQueue.main.async {
         guard let self else {
@@ -317,6 +329,10 @@ extension FoqosFilterManager: OSSystemExtensionRequestDelegate {
       return
     }
 
+    if request === activationRequest {
+      activationRequest = nil
+    }
+
     status = .failed(error.localizedDescription)
   }
 
@@ -353,8 +369,15 @@ extension FoqosFilterManager: OSSystemExtensionRequestDelegate {
       return
     }
 
+    guard request === activationRequest else {
+      return
+    }
+
+    activationRequest = nil
+
     switch result {
     case .completed:
+      isBundledExtensionActive = true
       configureFilter()
     case .willCompleteAfterReboot:
       status = .requiresRestart
@@ -375,15 +398,29 @@ extension FoqosFilterManager: OSSystemExtensionRequestDelegate {
       return
     }
 
-    let hasCurrentVersion = properties.contains { properties in
-      properties.isEnabled && properties.bundleVersion == bundledExtensionVersion
+    let installedExtensions = properties.map { properties in
+      FilterExtensionVersionPolicy.InstalledExtension(
+        bundleVersion: properties.bundleVersion,
+        isEnabled: properties.isEnabled
+      )
     }
+    let versionStatus = FilterExtensionVersionPolicy.status(
+      bundledVersion: bundledExtensionVersion,
+      installedExtensions: installedExtensions
+    )
 
-    guard hasCurrentVersion else {
+    switch versionStatus {
+    case .current:
+      isBundledExtensionActive = true
+      refreshStatus()
+    case .notConfigured:
+      isBundledExtensionActive = false
       status = .notConfigured
-      return
+    case .requiresUpdate(let installedVersion):
+      logger.info(
+        "Updating installed filter version \(installedVersion, privacy: .public) to the bundled version."
+      )
+      installAndEnable()
     }
-
-    refreshStatus()
   }
 }

--- a/FoqosMac/MenuBarContentView.swift
+++ b/FoqosMac/MenuBarContentView.swift
@@ -203,7 +203,7 @@ struct MenuBarContentView: View {
 
   private var showsSetupButton: Bool {
     switch filterManager.status {
-    case .disabled, .failed, .notConfigured:
+    case .approvalRequired, .disabled, .failed, .notConfigured:
       return true
     default:
       return false
@@ -211,7 +211,14 @@ struct MenuBarContentView: View {
   }
 
   private var setupButtonTitle: String {
-    filterManager.status == .disabled ? "Enable" : "Set Up"
+    switch filterManager.status {
+    case .approvalRequired:
+      return "Approve"
+    case .disabled:
+      return "Enable"
+    default:
+      return "Set Up"
+    }
   }
 
   private var filterStatusColor: Color {

--- a/FoqosMacTests/FilterExtensionVersionPolicyTests.swift
+++ b/FoqosMacTests/FilterExtensionVersionPolicyTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+final class FilterExtensionVersionPolicyTests: XCTestCase {
+  func testCurrentEnabledVersionDoesNotRequireActivation() {
+    let status = FilterExtensionVersionPolicy.status(
+      bundledVersion: "808",
+      installedExtensions: [installedExtension(version: "808", isEnabled: true)]
+    )
+
+    XCTAssertEqual(status, .current)
+  }
+
+  func testOlderEnabledVersionRequiresUpdate() {
+    let status = FilterExtensionVersionPolicy.status(
+      bundledVersion: "808",
+      installedExtensions: [installedExtension(version: "806", isEnabled: true)]
+    )
+
+    XCTAssertEqual(status, .requiresUpdate(installedVersion: "806"))
+  }
+
+  func testDisabledVersionPreservesSetupFlow() {
+    let status = FilterExtensionVersionPolicy.status(
+      bundledVersion: "808",
+      installedExtensions: [installedExtension(version: "806", isEnabled: false)]
+    )
+
+    XCTAssertEqual(status, .notConfigured)
+  }
+
+  func testNewerEnabledVersionIsNotDowngraded() {
+    let status = FilterExtensionVersionPolicy.status(
+      bundledVersion: "808",
+      installedExtensions: [installedExtension(version: "810", isEnabled: true)]
+    )
+
+    XCTAssertEqual(status, .current)
+  }
+
+  func testCurrentVersionTakesPrecedenceOverStaleVersions() {
+    let status = FilterExtensionVersionPolicy.status(
+      bundledVersion: "808",
+      installedExtensions: [
+        installedExtension(version: "806", isEnabled: true),
+        installedExtension(version: "808", isEnabled: true),
+      ]
+    )
+
+    XCTAssertEqual(status, .current)
+  }
+
+  func testMissingBundledVersionPreservesSetupFlow() {
+    let status = FilterExtensionVersionPolicy.status(
+      bundledVersion: nil,
+      installedExtensions: [installedExtension(version: "806", isEnabled: true)]
+    )
+
+    XCTAssertEqual(status, .notConfigured)
+  }
+
+  private func installedExtension(
+    version: String,
+    isEnabled: Bool
+  ) -> FilterExtensionVersionPolicy.InstalledExtension {
+    FilterExtensionVersionPolicy.InstalledExtension(
+      bundleVersion: version,
+      isEnabled: isEnabled
+    )
+  }
+}

--- a/FoqosShared/FilterExtensionVersionPolicy.swift
+++ b/FoqosShared/FilterExtensionVersionPolicy.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct FilterExtensionVersionPolicy {
+  struct InstalledExtension: Equatable {
+    let bundleVersion: String
+    let isEnabled: Bool
+  }
+
+  enum Status: Equatable {
+    case current
+    case notConfigured
+    case requiresUpdate(installedVersion: String)
+  }
+
+  static func status(
+    bundledVersion: String?,
+    installedExtensions: [InstalledExtension]
+  ) -> Status {
+    guard let bundledVersion else {
+      return .notConfigured
+    }
+
+    let enabledExtensions = installedExtensions.filter(\.isEnabled)
+    guard !enabledExtensions.isEmpty else {
+      return .notConfigured
+    }
+
+    let hasCurrentOrNewerVersion = enabledExtensions.contains { installedExtension in
+      installedExtension.bundleVersion.compare(bundledVersion, options: .numeric)
+        != .orderedAscending
+    }
+    if hasCurrentOrNewerVersion {
+      return .current
+    }
+
+    return .requiresUpdate(installedVersion: enabledExtensions[0].bundleVersion)
+  }
+}

--- a/foqos.xcodeproj/project.pbxproj
+++ b/foqos.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		F0B100012F90000100000001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = F0B100032F90000100000001 /* Sparkle */; };
 		F0C100012FA0000100000001 /* TLSClientHelloParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C100022FA0000100000001 /* TLSClientHelloParser.swift */; };
 		F0C1000C2FA0000100000001 /* FilterRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A300012F80000300000001 /* FilterRules.swift */; };
+		F0D100012FB0000100000001 /* FilterExtensionVersionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D100032FB0000100000001 /* FilterExtensionVersionPolicy.swift */; };
+		F0D100022FB0000100000001 /* FilterExtensionVersionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D100032FB0000100000001 /* FilterExtensionVersionPolicy.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -141,6 +143,7 @@
 		F0B100072F90000100000001 /* MacReleaseExportOptions.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = MacReleaseExportOptions.plist; sourceTree = "<group>"; };
 		F0C100022FA0000100000001 /* TLSClientHelloParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TLSClientHelloParser.swift; path = FoqosFilter/TLSClientHelloParser.swift; sourceTree = SOURCE_ROOT; };
 		F0C100032FA0000100000001 /* FoqosMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FoqosMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F0D100032FB0000100000001 /* FilterExtensionVersionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterExtensionVersionPolicy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -492,6 +495,7 @@
 		F0A300032F80000300000001 /* FoqosShared */ = {
 			isa = PBXGroup;
 			children = (
+				F0D100032FB0000100000001 /* FilterExtensionVersionPolicy.swift */,
 				F0A300012F80000300000001 /* FilterRules.swift */,
 				F0A300022F80000300000001 /* ActiveProfileSyncRecord.swift */,
 				F0A400012F80000400000001 /* Assets.xcassets */,
@@ -938,6 +942,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F0D100012FB0000100000001 /* FilterExtensionVersionPolicy.swift in Sources */,
 				F0A300052F80000300000001 /* FilterRules.swift in Sources */,
 				F0A300072F80000300000001 /* ActiveProfileSyncRecord.swift in Sources */,
 			);
@@ -955,6 +960,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F0D100022FB0000100000001 /* FilterExtensionVersionPolicy.swift in Sources */,
 				F0C1000C2FA0000100000001 /* FilterRules.swift in Sources */,
 				F0C100012FA0000100000001 /* TLSClientHelloParser.swift in Sources */,
 			);


### PR DESCRIPTION
## Summary

- automatically activate the bundled network-filter update when an older enabled version is detected after a Sparkle relaunch
- prevent `NEFilterManager` status refreshes from masking an extension-version mismatch while replacement is pending
- expose an approval action in the menu if macOS requires user approval
- add focused version-policy tests, including downgrade protection and stale-version handling

## Root cause

Sparkle correctly replaced the app bundle and embedded the `0.1.1` filter, but the app only inspected the installed system extension. It never submitted an activation request for the newer embedded version. Subsequent configuration refreshes saw the old filter as enabled and overwrote the mismatch state, hiding the setup action.

## Impact

After a future Sparkle update, an actively enabled older Foqos filter is replaced automatically. Fresh installs and disabled filters retain the existing setup flow. If replacement requires approval or a restart, the existing status UI remains visible instead of being overwritten.

## Validation

- `swift-format lint` on all touched Swift files
- `make mac-test` (10 tests passed)
- `make mac-build`
