### PR TITLE
Improve Mac sync discoverability

### DIFF
--- a/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
@@ -166,9 +166,10 @@ struct BlockedProfileDomainsFields: View {
     CustomToggle(
       title: "Sync to Mac",
       description:
-        "Sync blocked domains with the Foqos for Mac app.",
+        "Block the same selected domains on your Mac with the Foqos for Mac app.",
       isOn: $draft.enableMacSync,
-      isDisabled: disabled
+      isDisabled: disabled,
+      learnMoreURL: URL(string: "https://www.foqos.app/mac.html")
     )
     .onChange(of: draft.enableMacSync) { _, newValue in
       if newValue {

--- a/Foqos/Components/Common/CustomToggle.swift
+++ b/Foqos/Components/Common/CustomToggle.swift
@@ -8,6 +8,24 @@ struct CustomToggle: View {
   @Binding var isOn: Bool
   var isDisabled: Bool = false
   var errorMessage: String? = nil
+  var learnMoreURL: URL? = nil
+
+  private var attributedDescription: AttributedString {
+    var attributedDescription = AttributedString(description)
+
+    guard let learnMoreURL else {
+      return attributedDescription
+    }
+
+    attributedDescription.append(AttributedString(" "))
+
+    var learnMore = AttributedString("Learn more")
+    learnMore.link = learnMoreURL
+    learnMore.foregroundColor = themeManager.themeColor
+    attributedDescription.append(learnMore)
+
+    return attributedDescription
+  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -15,7 +33,7 @@ struct CustomToggle: View {
         .disabled(isDisabled)
         .tint(themeManager.themeColor)
 
-      Text(description)
+      Text(attributedDescription)
         .font(.caption)
         .foregroundColor(.secondary)
         .padding(.vertical, 4)

--- a/Foqos/Views/GuidedBlockedProfileCreationView.swift
+++ b/Foqos/Views/GuidedBlockedProfileCreationView.swift
@@ -82,7 +82,8 @@ private enum GuidedProfileStep: Int, CaseIterable, Identifiable {
     case .apps:
       return "Select the apps or categories this profile should restrict or allow."
     case .domains:
-      return "Add specific domains and decide whether Safari website blocking applies."
+      return
+        "Add specific domains, choose how they're blocked in Safari, and optionally sync them with Foqos for Mac."
     case .strictUnlocks:
       return
         "Some strategies let any NFC tag, QR code, or barcode unlock profiles. "


### PR DESCRIPTION
## Summary

- add an inline Learn more link to the Sync to Mac description
- make the toggle copy explain that selected domains are also blocked on Mac
- mention optional Foqos for Mac syncing in the guided Websites step

## Why

Mac syncing was available in the profile editor, but its purpose and the route to learn more were easy to miss. These changes make the feature more apparent while keeping the guidance within the existing domain configuration UI.

## User impact

People configuring blocked domains can understand what Mac sync does, open the Foqos for Mac page directly, and discover the option during guided setup.

## Validation

- `swift-format lint Foqos/Views/GuidedBlockedProfileCreationView.swift Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift Foqos/Components/Common/CustomToggle.swift`
- `git diff --check`
- `make build`