### PR TITLE
Fix Mac filter status after relaunch

### DIFF
--- a/FoqosMac/FoqosFilterManager.swift
+++ b/FoqosMac/FoqosFilterManager.swift
@@ -102,17 +102,10 @@ final class FoqosFilterManager: NSObject, ObservableObject {
   }
 
   private var bundledExtensionVersion: String? {
-    guard
-      let bundleURL = Bundle.main.url(
-        forResource: Self.extensionIdentifier,
-        withExtension: "systemextension",
-        subdirectory: "Contents/Library/SystemExtensions"
-      )
-    else {
-      return nil
-    }
-
-    return Bundle(url: bundleURL)?.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+    FilterExtensionBundleLocator.bundleVersion(
+      in: Bundle.main.bundleURL,
+      extensionIdentifier: Self.extensionIdentifier
+    )
   }
 
   func refreshStatus() {

--- a/FoqosMacTests/FilterExtensionBundleLocatorTests.swift
+++ b/FoqosMacTests/FilterExtensionBundleLocatorTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+
+final class FilterExtensionBundleLocatorTests: XCTestCase {
+  func testReadsVersionFromSystemExtensionsDirectory() throws {
+    let fileManager = FileManager.default
+    let applicationBundleURL = fileManager.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension("app")
+    defer {
+      try? fileManager.removeItem(at: applicationBundleURL)
+    }
+
+    let extensionIdentifier = "dev.ambitionsoftware.foqos.mac.filter"
+    let extensionContentsURL =
+      applicationBundleURL
+      .appendingPathComponent("Contents/Library/SystemExtensions", isDirectory: true)
+      .appendingPathComponent("\(extensionIdentifier).systemextension", isDirectory: true)
+      .appendingPathComponent("Contents", isDirectory: true)
+    try fileManager.createDirectory(at: extensionContentsURL, withIntermediateDirectories: true)
+
+    let infoDictionary: [String: Any] = [
+      "CFBundleIdentifier": extensionIdentifier,
+      "CFBundlePackageType": "SYSX",
+      "CFBundleVersion": "811",
+    ]
+    let infoData = try PropertyListSerialization.data(
+      fromPropertyList: infoDictionary,
+      format: .xml,
+      options: 0
+    )
+    try infoData.write(to: extensionContentsURL.appendingPathComponent("Info.plist"))
+
+    let version = FilterExtensionBundleLocator.bundleVersion(
+      in: applicationBundleURL,
+      extensionIdentifier: extensionIdentifier
+    )
+
+    XCTAssertEqual(version, "811")
+  }
+}

--- a/FoqosShared/FilterExtensionBundleLocator.swift
+++ b/FoqosShared/FilterExtensionBundleLocator.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct FilterExtensionBundleLocator {
+  static func bundleVersion(
+    in applicationBundleURL: URL,
+    extensionIdentifier: String
+  ) -> String? {
+    let systemExtensionsURL =
+      applicationBundleURL
+      .appendingPathComponent("Contents/Library/SystemExtensions", isDirectory: true)
+    let extensionBundleURL =
+      systemExtensionsURL
+      .appendingPathComponent("\(extensionIdentifier).systemextension", isDirectory: true)
+
+    return Bundle(url: extensionBundleURL)?
+      .object(forInfoDictionaryKey: "CFBundleVersion") as? String
+  }
+}

--- a/foqos.xcodeproj/project.pbxproj
+++ b/foqos.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		F0C1000C2FA0000100000001 /* FilterRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A300012F80000300000001 /* FilterRules.swift */; };
 		F0D100012FB0000100000001 /* FilterExtensionVersionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D100032FB0000100000001 /* FilterExtensionVersionPolicy.swift */; };
 		F0D100022FB0000100000001 /* FilterExtensionVersionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D100032FB0000100000001 /* FilterExtensionVersionPolicy.swift */; };
+		F0E100012FC0000100000001 /* FilterExtensionBundleLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E100032FC0000100000001 /* FilterExtensionBundleLocator.swift */; };
+		F0E100022FC0000100000001 /* FilterExtensionBundleLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E100032FC0000100000001 /* FilterExtensionBundleLocator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -144,6 +146,7 @@
 		F0C100022FA0000100000001 /* TLSClientHelloParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TLSClientHelloParser.swift; path = FoqosFilter/TLSClientHelloParser.swift; sourceTree = SOURCE_ROOT; };
 		F0C100032FA0000100000001 /* FoqosMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FoqosMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F0D100032FB0000100000001 /* FilterExtensionVersionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterExtensionVersionPolicy.swift; sourceTree = "<group>"; };
+		F0E100032FC0000100000001 /* FilterExtensionBundleLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterExtensionBundleLocator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -495,6 +498,7 @@
 		F0A300032F80000300000001 /* FoqosShared */ = {
 			isa = PBXGroup;
 			children = (
+				F0E100032FC0000100000001 /* FilterExtensionBundleLocator.swift */,
 				F0D100032FB0000100000001 /* FilterExtensionVersionPolicy.swift */,
 				F0A300012F80000300000001 /* FilterRules.swift */,
 				F0A300022F80000300000001 /* ActiveProfileSyncRecord.swift */,
@@ -942,6 +946,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F0E100012FC0000100000001 /* FilterExtensionBundleLocator.swift in Sources */,
 				F0D100012FB0000100000001 /* FilterExtensionVersionPolicy.swift in Sources */,
 				F0A300052F80000300000001 /* FilterRules.swift in Sources */,
 				F0A300072F80000300000001 /* ActiveProfileSyncRecord.swift in Sources */,
@@ -960,6 +965,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F0E100022FC0000100000001 /* FilterExtensionBundleLocator.swift in Sources */,
 				F0D100022FB0000100000001 /* FilterExtensionVersionPolicy.swift in Sources */,
 				F0C1000C2FA0000100000001 /* FilterRules.swift in Sources */,
 				F0C100012FA0000100000001 /* TLSClientHelloParser.swift in Sources */,


### PR DESCRIPTION
## Summary

- read the embedded system extension from the app bundle's `Contents/Library/SystemExtensions` directory
- add a reusable bundle locator for the Mac filter manager
- add a regression test that constructs the real system-extension bundle layout and verifies its build version is readable

## Root cause

The Mac app used `Bundle.url(forResource:withExtension:subdirectory:)` to locate the embedded system extension. That API searches relative to `Contents/Resources`, but macOS embeds system extensions under `Contents/Library/SystemExtensions`. The lookup therefore returned `nil` after every process launch.

A missing bundled version was classified as `notConfigured`, leaving the in-memory extension-active flag false and preventing the app from loading the persisted `NEFilterManager` configuration. Completing setup temporarily set the flag for the current process, so the problem returned after quitting, crashing, or force-killing and reopening the app.

## Impact

After setup has completed, relaunching Foqos for Mac now finds the embedded extension version and restores the persisted filter status without asking the user to repeat setup.

## Validation

- `make mac-test` — 11 tests passed
- `make mac-build` — signed Mac app and embedded system extension built successfully
- `make lint` — completed successfully; touched Swift files pass formatting with unrelated existing widget warnings
- manually installed with `make mac-dev`; macOS reports filter build 811 as activated and enabled, and the provider received configuration updates