### PR TITLE
Add profile Home Screen quick actions

### DIFF
--- a/Foqos/Utils/QuickActionManager.swift
+++ b/Foqos/Utils/QuickActionManager.swift
@@ -7,7 +7,6 @@ final class QuickActionManager: ObservableObject {
 
   static let profileStartActionType = "dev.ambitionsoftware.foqos.start-profile"
   static let profileIDUserInfoKey = "profileID"
-  static let maximumDynamicActions = 4
 
   @Published private(set) var pendingProfileID: UUID?
 
@@ -24,7 +23,7 @@ final class QuickActionManager: ObservableObject {
       return lhs.id.uuidString < rhs.id.uuidString
     }
 
-    return sortedProfiles.prefix(maximumDynamicActions).map { profile in
+    return sortedProfiles.map { profile in
       UIApplicationShortcutItem(
         type: profileStartActionType,
         localizedTitle: "Start \(profile.name)",

--- a/Foqos/Utils/QuickActionManager.swift
+++ b/Foqos/Utils/QuickActionManager.swift
@@ -1,0 +1,129 @@
+import Combine
+import UIKit
+
+@MainActor
+final class QuickActionManager: ObservableObject {
+  static let shared = QuickActionManager()
+
+  static let profileStartActionType = "dev.ambitionsoftware.foqos.start-profile"
+  static let profileIDUserInfoKey = "profileID"
+  static let maximumDynamicActions = 4
+
+  @Published private(set) var pendingProfileID: UUID?
+
+  static func shortcutItems(from profiles: [BlockedProfiles]) -> [UIApplicationShortcutItem] {
+    let sortedProfiles = profiles.sorted { lhs, rhs in
+      if lhs.order != rhs.order {
+        return lhs.order < rhs.order
+      }
+
+      if lhs.createdAt != rhs.createdAt {
+        return lhs.createdAt > rhs.createdAt
+      }
+
+      return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    return sortedProfiles.prefix(maximumDynamicActions).map { profile in
+      UIApplicationShortcutItem(
+        type: profileStartActionType,
+        localizedTitle: "Start \(profile.name)",
+        localizedSubtitle: nil,
+        icon: nil,
+        userInfo: [profileIDUserInfoKey: profile.id.uuidString as NSString]
+      )
+    }
+  }
+
+  static func profileID(from shortcutItem: UIApplicationShortcutItem) -> UUID? {
+    guard shortcutItem.type == profileStartActionType,
+      let rawProfileID = shortcutItem.userInfo?[profileIDUserInfoKey]
+    else {
+      return nil
+    }
+
+    if let profileIDString = rawProfileID as? String {
+      return UUID(uuidString: profileIDString)
+    }
+
+    if let profileIDString = rawProfileID as? NSString {
+      return UUID(uuidString: profileIDString as String)
+    }
+
+    return nil
+  }
+
+  func handle(_ shortcutItem: UIApplicationShortcutItem) {
+    guard let profileID = Self.profileID(from: shortcutItem) else {
+      return
+    }
+
+    pendingProfileID = profileID
+  }
+
+  func clearPendingProfileStart() {
+    pendingProfileID = nil
+  }
+
+  func refreshActions(from profiles: [BlockedProfiles]) {
+    UIApplication.shared.shortcutItems = Self.shortcutItems(from: profiles)
+  }
+}
+
+final class FoqosAppDelegate: NSObject, UIApplicationDelegate {
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    if let shortcutItem = launchOptions?[.shortcutItem] as? UIApplicationShortcutItem {
+      Task { @MainActor in
+        QuickActionManager.shared.handle(shortcutItem)
+      }
+    }
+
+    return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    performActionFor shortcutItem: UIApplicationShortcutItem,
+    completionHandler: @escaping (Bool) -> Void
+  ) {
+    Task { @MainActor in
+      QuickActionManager.shared.handle(shortcutItem)
+      completionHandler(true)
+    }
+  }
+
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    if let shortcutItem = options.shortcutItem {
+      Task { @MainActor in
+        QuickActionManager.shared.handle(shortcutItem)
+      }
+    }
+
+    let configuration = UISceneConfiguration(
+      name: "Default Configuration",
+      sessionRole: connectingSceneSession.role
+    )
+    configuration.delegateClass = FoqosSceneDelegate.self
+    return configuration
+  }
+}
+
+final class FoqosSceneDelegate: NSObject, UIWindowSceneDelegate {
+  func windowScene(
+    _ windowScene: UIWindowScene,
+    performActionFor shortcutItem: UIApplicationShortcutItem,
+    completionHandler: @escaping (Bool) -> Void
+  ) {
+    Task { @MainActor in
+      QuickActionManager.shared.handle(shortcutItem)
+      completionHandler(true)
+    }
+  }
+}

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -12,8 +12,10 @@ struct HomeView: View {
   @EnvironmentObject var alertsManager: AlertsManager
   @EnvironmentObject var navigationManager: NavigationManager
   @EnvironmentObject var ratingManager: RatingManager
+  @EnvironmentObject var quickActionManager: QuickActionManager
 
   // Profile management
+  @State private var hasLoadedProfiles = false
   @Query(sort: [
     SortDescriptor(\BlockedProfiles.order, order: .forward),
     SortDescriptor(\BlockedProfiles.createdAt, order: .reverse),
@@ -83,6 +85,12 @@ struct HomeView: View {
 
   var isPauseActive: Bool {
     return strategyManager.isPauseActive
+  }
+
+  private var quickActionProfileSignature: String {
+    profiles.map {
+      "\($0.id.uuidString):\($0.name):\($0.order):\($0.createdAt.timeIntervalSinceReferenceDate)"
+    }.joined(separator: "|")
   }
 
   private var canCreateProfiles: Bool {
@@ -223,17 +231,24 @@ struct HomeView: View {
       }
       refreshAlerts()
     }
-    .onChange(of: profiles) { oldValue, newValue in
+    .onChange(of: profiles) { _, newValue in
+      hasLoadedProfiles = true
       if !newValue.isEmpty {
         loadApp()
       }
       refreshAlerts()
     }
-    .onChange(of: scenePhase) { oldPhase, newPhase in
+    .onChange(of: quickActionProfileSignature) { _, _ in
+      refreshQuickActions()
+      consumePendingQuickActionIfReady()
+    }
+    .onChange(of: scenePhase) { _, newPhase in
       if newPhase == .active {
         requestAuthorizer.refreshAuthorizationStatus()
         loadApp()
         refreshAlerts()
+        refreshQuickActions()
+        consumePendingQuickActionIfReady()
       } else if newPhase == .background {
         unloadApp()
       }
@@ -248,7 +263,13 @@ struct HomeView: View {
       showErrorAlert(message: message)
     }
     .onAppear {
+      hasLoadedProfiles = true
       onAppearApp()
+      refreshQuickActions()
+      consumePendingQuickActionIfReady()
+    }
+    .onChange(of: quickActionManager.pendingProfileID) { _, _ in
+      consumePendingQuickActionIfReady()
     }
     .sheet(item: $alertsManager.selectedAlert) { alert in
       HomeAlertDetailView(
@@ -382,6 +403,26 @@ struct HomeView: View {
     refreshAlerts()
   }
 
+  private func refreshQuickActions() {
+    quickActionManager.refreshActions(from: profiles)
+  }
+
+  private func consumePendingQuickActionIfReady() {
+    guard scenePhase == .active, hasLoadedProfiles,
+      let profileID = quickActionManager.pendingProfileID
+    else {
+      return
+    }
+
+    guard let profile = profiles.first(where: { $0.id == profileID }) else {
+      quickActionManager.clearPendingProfileStart()
+      return
+    }
+
+    startProfile(profile)
+    quickActionManager.clearPendingProfileStart()
+  }
+
   private func refreshAlerts() {
     alertsManager.refreshAlerts(
       profiles: profiles,
@@ -437,6 +478,7 @@ struct HomeView: View {
     .environmentObject(AlertsManager())
     .environmentObject(NavigationManager())
     .environmentObject(StrategyManager())
+    .environmentObject(QuickActionManager())
     .defaultAppStorage(UserDefaults(suiteName: "preview")!)
     .onAppear {
       UserDefaults(suiteName: "preview")!.set(

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -15,7 +15,6 @@ struct HomeView: View {
   @EnvironmentObject var quickActionManager: QuickActionManager
 
   // Profile management
-  @State private var hasLoadedProfiles = false
   @Query(sort: [
     SortDescriptor(\BlockedProfiles.order, order: .forward),
     SortDescriptor(\BlockedProfiles.createdAt, order: .reverse),
@@ -232,7 +231,6 @@ struct HomeView: View {
       refreshAlerts()
     }
     .onChange(of: profiles) { _, newValue in
-      hasLoadedProfiles = true
       if !newValue.isEmpty {
         loadApp()
       }
@@ -263,7 +261,6 @@ struct HomeView: View {
       showErrorAlert(message: message)
     }
     .onAppear {
-      hasLoadedProfiles = true
       onAppearApp()
       refreshQuickActions()
       consumePendingQuickActionIfReady()
@@ -408,14 +405,21 @@ struct HomeView: View {
   }
 
   private func consumePendingQuickActionIfReady() {
-    guard scenePhase == .active, hasLoadedProfiles,
+    guard scenePhase == .active,
       let profileID = quickActionManager.pendingProfileID
     else {
       return
     }
 
-    guard let profile = profiles.first(where: { $0.id == profileID }) else {
-      quickActionManager.clearPendingProfileStart()
+    let profile: BlockedProfiles
+    do {
+      guard let fetchedProfile = try BlockedProfiles.findProfile(byID: profileID, in: context) else {
+        quickActionManager.clearPendingProfileStart()
+        return
+      }
+      profile = fetchedProfile
+    } catch {
+      // Keep the request so a later lifecycle or profile update can retry it.
       return
     }
 

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -419,6 +419,11 @@ struct HomeView: View {
       return
     }
 
+    guard activeSessionProfileId != profileID else {
+      quickActionManager.clearPendingProfileStart()
+      return
+    }
+
     startProfile(profile)
     quickActionManager.clearPendingProfileStart()
   }

--- a/Foqos/foqosApp.swift
+++ b/Foqos/foqosApp.swift
@@ -34,6 +34,8 @@ struct foqosApp: App {
   @StateObject private var navigationManager = NavigationManager()
   @StateObject private var nfcWriter = NFCWriter()
   @StateObject private var ratingManager = RatingManager()
+  @StateObject private var quickActionManager = QuickActionManager.shared
+  @UIApplicationDelegateAdaptor(FoqosAppDelegate.self) private var appDelegate
 
   // Singletons for shared functionality
   @StateObject private var startegyManager = StrategyManager.shared
@@ -75,6 +77,7 @@ struct foqosApp: App {
         .environmentObject(navigationManager)
         .environmentObject(nfcWriter)
         .environmentObject(ratingManager)
+        .environmentObject(quickActionManager)
         .environmentObject(liveActivityManager)
         .environmentObject(themeManager)
     }

--- a/foqosTests/QuickActionManagerTests.swift
+++ b/foqosTests/QuickActionManagerTests.swift
@@ -5,37 +5,29 @@ import XCTest
 
 @MainActor
 final class QuickActionManagerTests: XCTestCase {
-  func testShortcutItemsUseProfileNamesAndIDs() {
+  func testShortcutItemUsesProfileNameAndID() throws {
     let profileID = UUID()
     let profile = BlockedProfiles(id: profileID, name: "Work", order: 0)
 
-    let shortcut = try! XCTUnwrap(QuickActionManager.shortcutItems(from: [profile]).first)
+    let shortcut = try XCTUnwrap(QuickActionManager.shortcutItems(from: [profile]).first)
 
     XCTAssertEqual(shortcut.localizedTitle, "Start Work")
     XCTAssertEqual(QuickActionManager.profileID(from: shortcut), profileID)
   }
 
-  func testShortcutItemsAreSortedByOrderAndCreationDateWithoutTruncatingProfiles() {
+  func testShortcutItemsSortByOrderThenNewestCreationDate() {
     let now = Date()
     let newest = BlockedProfiles(
       id: UUID(), name: "Newest", createdAt: now.addingTimeInterval(1), order: 1)
     let oldest = BlockedProfiles(
       id: UUID(), name: "Oldest", createdAt: now, order: 1)
     let first = BlockedProfiles(id: UUID(), name: "First", createdAt: now, order: 0)
-    let additionalProfiles = (0..<5).map { index in
-      BlockedProfiles(id: UUID(), name: "Extra \(index)", createdAt: now, order: index + 2)
-    }
-    let profiles = [additionalProfiles, [oldest, newest, first]].flatMap { $0 }
 
-    let shortcuts = QuickActionManager.shortcutItems(from: profiles)
+    let shortcuts = QuickActionManager.shortcutItems(from: [oldest, newest, first])
 
-    XCTAssertEqual(shortcuts.count, profiles.count)
     XCTAssertEqual(
       shortcuts.map(\.localizedTitle),
-      [
-        "Start First", "Start Newest", "Start Oldest", "Start Extra 0", "Start Extra 1",
-        "Start Extra 2", "Start Extra 3", "Start Extra 4",
-      ]
+      ["Start First", "Start Newest", "Start Oldest"]
     )
   }
 
@@ -50,6 +42,18 @@ final class QuickActionManagerTests: XCTestCase {
       localizedSubtitle: nil,
       icon: nil,
       userInfo: [QuickActionManager.profileIDUserInfoKey: "not-a-uuid" as NSString]
+    )
+
+    XCTAssertNil(QuickActionManager.profileID(from: shortcut))
+  }
+
+  func testUnknownShortcutTypeIsIgnored() {
+    let shortcut = UIApplicationShortcutItem(
+      type: "unknown-action",
+      localizedTitle: "Start Work",
+      localizedSubtitle: nil,
+      icon: nil,
+      userInfo: [QuickActionManager.profileIDUserInfoKey: UUID().uuidString as NSString]
     )
 
     XCTAssertNil(QuickActionManager.profileID(from: shortcut))
@@ -71,5 +75,26 @@ final class QuickActionManagerTests: XCTestCase {
 
     manager.clearPendingProfileStart()
     XCTAssertNil(manager.pendingProfileID)
+  }
+
+  func testNewPendingRequestReplacesPreviousRequest() {
+    let manager = QuickActionManager()
+    let firstProfileID = UUID()
+    let secondProfileID = UUID()
+
+    manager.handle(makeShortcut(for: firstProfileID))
+    manager.handle(makeShortcut(for: secondProfileID))
+
+    XCTAssertEqual(manager.pendingProfileID, secondProfileID)
+  }
+
+  private func makeShortcut(for profileID: UUID) -> UIApplicationShortcutItem {
+    UIApplicationShortcutItem(
+      type: QuickActionManager.profileStartActionType,
+      localizedTitle: "Start Work",
+      localizedSubtitle: nil,
+      icon: nil,
+      userInfo: [QuickActionManager.profileIDUserInfoKey: profileID.uuidString as NSString]
+    )
   }
 }

--- a/foqosTests/QuickActionManagerTests.swift
+++ b/foqosTests/QuickActionManagerTests.swift
@@ -47,6 +47,8 @@ final class QuickActionManagerTests: XCTestCase {
     let shortcut = UIApplicationShortcutItem(
       type: QuickActionManager.profileStartActionType,
       localizedTitle: "Start Work",
+      localizedSubtitle: nil,
+      icon: nil,
       userInfo: [QuickActionManager.profileIDUserInfoKey: "not-a-uuid" as NSString]
     )
 
@@ -59,6 +61,8 @@ final class QuickActionManagerTests: XCTestCase {
     let shortcut = UIApplicationShortcutItem(
       type: QuickActionManager.profileStartActionType,
       localizedTitle: "Start Work",
+      localizedSubtitle: nil,
+      icon: nil,
       userInfo: [QuickActionManager.profileIDUserInfoKey: profileID.uuidString as NSString]
     )
 

--- a/foqosTests/QuickActionManagerTests.swift
+++ b/foqosTests/QuickActionManagerTests.swift
@@ -15,24 +15,27 @@ final class QuickActionManagerTests: XCTestCase {
     XCTAssertEqual(QuickActionManager.profileID(from: shortcut), profileID)
   }
 
-  func testShortcutItemsAreSortedByOrderThenCreationDateAndLimited() {
+  func testShortcutItemsAreSortedByOrderAndCreationDateWithoutTruncatingProfiles() {
     let now = Date()
     let newest = BlockedProfiles(
       id: UUID(), name: "Newest", createdAt: now.addingTimeInterval(1), order: 1)
     let oldest = BlockedProfiles(
       id: UUID(), name: "Oldest", createdAt: now, order: 1)
     let first = BlockedProfiles(id: UUID(), name: "First", createdAt: now, order: 0)
-    let extraProfiles = (0..<QuickActionManager.maximumDynamicActions).map { index in
+    let additionalProfiles = (0..<5).map { index in
       BlockedProfiles(id: UUID(), name: "Extra \(index)", createdAt: now, order: index + 2)
     }
+    let profiles = [additionalProfiles, [oldest, newest, first]].flatMap { $0 }
 
-    let shortcuts = QuickActionManager.shortcutItems(
-      from: [extraProfiles, [oldest, newest, first]].flatMap { $0 })
+    let shortcuts = QuickActionManager.shortcutItems(from: profiles)
 
-    XCTAssertEqual(shortcuts.count, QuickActionManager.maximumDynamicActions)
+    XCTAssertEqual(shortcuts.count, profiles.count)
     XCTAssertEqual(
       shortcuts.map(\.localizedTitle),
-      ["Start First", "Start Newest", "Start Oldest", "Start Extra 0"]
+      [
+        "Start First", "Start Newest", "Start Oldest", "Start Extra 0", "Start Extra 1",
+        "Start Extra 2", "Start Extra 3", "Start Extra 4",
+      ]
     )
   }
 

--- a/foqosTests/QuickActionManagerTests.swift
+++ b/foqosTests/QuickActionManagerTests.swift
@@ -1,0 +1,68 @@
+import UIKit
+import XCTest
+
+@testable import foqos
+
+@MainActor
+final class QuickActionManagerTests: XCTestCase {
+  func testShortcutItemsUseProfileNamesAndIDs() {
+    let profileID = UUID()
+    let profile = BlockedProfiles(id: profileID, name: "Work", order: 0)
+
+    let shortcut = try! XCTUnwrap(QuickActionManager.shortcutItems(from: [profile]).first)
+
+    XCTAssertEqual(shortcut.localizedTitle, "Start Work")
+    XCTAssertEqual(QuickActionManager.profileID(from: shortcut), profileID)
+  }
+
+  func testShortcutItemsAreSortedByOrderThenCreationDateAndLimited() {
+    let now = Date()
+    let newest = BlockedProfiles(
+      id: UUID(), name: "Newest", createdAt: now.addingTimeInterval(1), order: 1)
+    let oldest = BlockedProfiles(
+      id: UUID(), name: "Oldest", createdAt: now, order: 1)
+    let first = BlockedProfiles(id: UUID(), name: "First", createdAt: now, order: 0)
+    let extraProfiles = (0..<QuickActionManager.maximumDynamicActions).map { index in
+      BlockedProfiles(id: UUID(), name: "Extra \(index)", createdAt: now, order: index + 2)
+    }
+
+    let shortcuts = QuickActionManager.shortcutItems(
+      from: [extraProfiles, [oldest, newest, first]].flatMap { $0 })
+
+    XCTAssertEqual(shortcuts.count, QuickActionManager.maximumDynamicActions)
+    XCTAssertEqual(
+      shortcuts.map(\.localizedTitle),
+      ["Start First", "Start Newest", "Start Oldest", "Start Extra 0"]
+    )
+  }
+
+  func testNoProfilesProducesNoShortcuts() {
+    XCTAssertTrue(QuickActionManager.shortcutItems(from: []).isEmpty)
+  }
+
+  func testMalformedShortcutIsIgnored() {
+    let shortcut = UIApplicationShortcutItem(
+      type: QuickActionManager.profileStartActionType,
+      localizedTitle: "Start Work",
+      userInfo: [QuickActionManager.profileIDUserInfoKey: "not-a-uuid" as NSString]
+    )
+
+    XCTAssertNil(QuickActionManager.profileID(from: shortcut))
+  }
+
+  func testPendingRequestRemainsUntilExplicitlyConsumed() {
+    let manager = QuickActionManager()
+    let profileID = UUID()
+    let shortcut = UIApplicationShortcutItem(
+      type: QuickActionManager.profileStartActionType,
+      localizedTitle: "Start Work",
+      userInfo: [QuickActionManager.profileIDUserInfoKey: profileID.uuidString as NSString]
+    )
+
+    manager.handle(shortcut)
+    XCTAssertEqual(manager.pendingProfileID, profileID)
+
+    manager.clearPendingProfileStart()
+    XCTAssertNil(manager.pendingProfileID)
+  }
+}


### PR DESCRIPTION
Solves https://github.com/awaseem/foqos/issues/465

## Summary
- Add dynamic Home Screen quick actions for the ordered profiles.
- Route cold-launch and foreground shortcut requests through the existing HomeView start flow.
- Preserve strategy-specific UI and ignore stale or duplicate profile requests safely.
- Add focused tests for action construction, ordering, payload validation, and pending requests..

## AI Disclaimer
This was done with the help of GPT 5.6 Luna. I am a web dev by day and an open source enthusiast by night.

## Validation
https://github.com/user-attachments/assets/f0339bc5-0535-4585-a540-053d3ec06a11

