### PR TITLE
Improve Mac filter onboarding and menu bar actions

### DIFF
--- a/FoqosMac/FoqosFilterManager.swift
+++ b/FoqosMac/FoqosFilterManager.swift
@@ -42,8 +42,8 @@ final class FoqosFilterManager: NSObject, ObservableObject {
       return "Installing the Foqos network extension."
     case .approvalRequired:
       return """
-        In Login Items & Extensions, choose By Category and enable Foqos Website Filter under \
-        Network Extensions.
+        In Login Items & Extensions, scroll down to Extensions, choose By Category, then enable \
+        Foqos Website Filter under Network Extensions.
         """
     case .configuringFilter:
       return "Choose Allow when macOS asks Foqos to filter network content."

--- a/FoqosMac/FoqosFilterManager.swift
+++ b/FoqosMac/FoqosFilterManager.swift
@@ -5,11 +5,12 @@ import SystemExtensions
 
 final class FoqosFilterManager: NSObject, ObservableObject {
   enum Status: Equatable {
+    case activatingExtension
     case approvalRequired
+    case configuringFilter
     case disabled
     case enabled
     case failed(String)
-    case installing
     case notConfigured
     case requiresRestart
     case unknown
@@ -37,16 +38,21 @@ final class FoqosFilterManager: NSObject, ObservableObject {
 
   var statusText: String {
     switch status {
+    case .activatingExtension:
+      return "Installing the Foqos network extension."
     case .approvalRequired:
-      return "Enable Foqos in System Settings › Network › Filters to finish setup."
+      return """
+        In Login Items & Extensions, choose By Category and enable Foqos Website Filter under \
+        Network Extensions.
+        """
+    case .configuringFilter:
+      return "Choose Allow when macOS asks Foqos to filter network content."
     case .disabled:
       return "Active profiles cannot block websites while the network filter is disabled."
     case .enabled:
       return "Active profiles can block websites across supported browsers."
     case .failed(let message):
       return message
-    case .installing:
-      return "macOS may ask you to approve the Foqos network filter."
     case .notConfigured:
       return "Set up the network filter to block websites across browsers."
     case .requiresRestart:
@@ -80,7 +86,7 @@ final class FoqosFilterManager: NSObject, ObservableObject {
     }
 
     isBundledExtensionActive = false
-    status = .installing
+    status = .activatingExtension
 
     let request = OSSystemExtensionRequest.activationRequest(
       forExtensionWithIdentifier: Self.extensionIdentifier,
@@ -201,6 +207,8 @@ final class FoqosFilterManager: NSObject, ObservableObject {
   #endif
 
   private func configureFilter() {
+    status = .configuringFilter
+
     let manager = NEFilterManager.shared()
     manager.loadFromPreferences { [weak self] error in
       guard let self, error == nil else {
@@ -380,6 +388,10 @@ extension FoqosFilterManager: OSSystemExtensionRequestDelegate {
   }
 
   func requestNeedsUserApproval(_ request: OSSystemExtensionRequest) {
+    guard request === activationRequest else {
+      return
+    }
+
     status = .approvalRequired
   }
 

--- a/FoqosMac/FoqosMacApp.swift
+++ b/FoqosMac/FoqosMacApp.swift
@@ -65,7 +65,7 @@ struct FoqosMacApp: App {
       return "exclamationmark.triangle.fill"
     case .enabled:
       return controller.isBlocking ? "hourglass.circle.fill" : "hourglass"
-    case .installing, .unknown:
+    case .activatingExtension, .configuringFilter, .unknown:
       return "hourglass"
     }
   }

--- a/FoqosMac/FoqosOnboardingWindowController.swift
+++ b/FoqosMac/FoqosOnboardingWindowController.swift
@@ -42,7 +42,7 @@ final class FoqosOnboardingWindowController: NSObject, ObservableObject {
 
     let hostingController = NSHostingController(rootView: onboardingView)
     let window = NSWindow(
-      contentRect: NSRect(x: 0, y: 0, width: 520, height: 540),
+      contentRect: NSRect(x: 0, y: 0, width: 520, height: 620),
       styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
       backing: .buffered,
       defer: false
@@ -53,9 +53,9 @@ final class FoqosOnboardingWindowController: NSObject, ObservableObject {
     window.isMovableByWindowBackground = true
     window.isReleasedWhenClosed = false
     window.backgroundColor = .clear
-    window.contentMinSize = NSSize(width: 480, height: 500)
+    window.contentMinSize = NSSize(width: 480, height: 580)
     window.contentViewController = hostingController
-    window.setContentSize(NSSize(width: 520, height: 540))
+    window.setContentSize(NSSize(width: 520, height: 620))
     window.center()
     window.standardWindowButton(.zoomButton)?.isHidden = true
 

--- a/FoqosMac/MacOnboardingView.swift
+++ b/FoqosMac/MacOnboardingView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ServiceManagement
 import SwiftUI
 
 struct MacOnboardingView: View {
@@ -22,7 +23,7 @@ struct MacOnboardingView: View {
 
       VStack(spacing: 0) {
         SetupProgressRow(
-          title: "Install the website filter",
+          title: "Install the Foqos network extension",
           symbol: "puzzlepiece.extension",
           state: installationStepState
         )
@@ -31,18 +32,20 @@ struct MacOnboardingView: View {
           .padding(.leading, 42)
 
         SetupProgressRow(
-          title: "Approve Foqos in System Settings",
+          title: "Enable Foqos in Login Items & Extensions",
           symbol: "checkmark.shield",
-          state: approvalStepState
+          state: approvalStepState,
+          detail: approvalStepDetail
         )
 
         Divider()
           .padding(.leading, 42)
 
         SetupProgressRow(
-          title: "Ready for focused sessions",
-          symbol: "sparkles",
-          state: readyStepState
+          title: "Allow network content filtering",
+          symbol: "network.badge.shield.half.filled",
+          state: filterStepState,
+          detail: filterStepDetail
         )
       }
       .frame(maxWidth: 390)
@@ -70,7 +73,7 @@ struct MacOnboardingView: View {
     }
     .padding(.horizontal, 48)
     .padding(.vertical, 38)
-    .frame(minWidth: 480, maxWidth: .infinity, minHeight: 500, maxHeight: .infinity)
+    .frame(minWidth: 480, maxWidth: .infinity, minHeight: 580, maxHeight: .infinity)
     .background {
       Color.white
         .ignoresSafeArea()
@@ -88,9 +91,9 @@ struct MacOnboardingView: View {
 
   private var installationStepState: SetupProgressRow.State {
     switch filterManager.status {
-    case .approvalRequired, .disabled, .enabled, .requiresRestart:
+    case .approvalRequired, .configuringFilter, .disabled, .enabled, .requiresRestart:
       return .complete
-    case .installing:
+    case .activatingExtension:
       return .active
     case .failed, .notConfigured:
       return .active
@@ -101,33 +104,67 @@ struct MacOnboardingView: View {
 
   private var approvalStepState: SetupProgressRow.State {
     switch filterManager.status {
-    case .approvalRequired, .disabled:
+    case .approvalRequired:
       return .active
-    case .enabled, .requiresRestart:
+    case .configuringFilter, .disabled, .enabled, .requiresRestart:
       return .complete
-    case .failed, .installing, .notConfigured, .unknown:
+    case .activatingExtension, .failed, .notConfigured, .unknown:
       return .pending
     }
   }
 
-  private var readyStepState: SetupProgressRow.State {
-    filterManager.status == .enabled ? .complete : .pending
+  private var approvalStepDetail: String? {
+    guard filterManager.status == .approvalRequired else {
+      return nil
+    }
+
+    return """
+      Choose By Category, open Network Extensions, then turn on Foqos Website Filter. Return to \
+      Foqos when it is enabled.
+      """
+  }
+
+  private var filterStepState: SetupProgressRow.State {
+    switch filterManager.status {
+    case .configuringFilter, .disabled:
+      return .active
+    case .enabled:
+      return .complete
+    case .activatingExtension, .approvalRequired, .failed, .notConfigured, .requiresRestart,
+      .unknown:
+      return .pending
+    }
+  }
+
+  private var filterStepDetail: String? {
+    guard filterManager.status == .configuringFilter else {
+      return nil
+    }
+
+    return "Choose Allow in the macOS permission prompt to enable website blocking."
   }
 
   private var isWorking: Bool {
-    filterManager.status == .installing || filterManager.status == .unknown
+    switch filterManager.status {
+    case .activatingExtension, .configuringFilter, .unknown:
+      return true
+    default:
+      return false
+    }
   }
 
   private var primaryButtonTitle: String {
     switch filterManager.status {
+    case .activatingExtension:
+      return "Installing Extension…"
     case .approvalRequired:
-      return "Open System Settings"
+      return "Open Login Items & Extensions"
+    case .configuringFilter:
+      return "Waiting for Permission…"
     case .enabled:
       return "Complete"
     case .failed:
       return "Try Again"
-    case .installing:
-      return "Completing Setup…"
     case .requiresRestart:
       return "Restart to Complete"
     case .disabled, .notConfigured:
@@ -153,21 +190,16 @@ struct MacOnboardingView: View {
   private func handlePrimaryAction() {
     switch filterManager.status {
     case .approvalRequired:
-      openSystemSettings()
+      SMAppService.openSystemSettingsLoginItems()
     case .disabled, .failed, .notConfigured:
       filterManager.installAndEnable()
     case .enabled:
       onComplete()
     case .requiresRestart:
       onDismiss()
-    case .installing, .unknown:
+    case .activatingExtension, .configuringFilter, .unknown:
       break
     }
-  }
-
-  private func openSystemSettings() {
-    let settingsURL = URL(fileURLWithPath: "/System/Applications/System Settings.app")
-    NSWorkspace.shared.open(settingsURL)
   }
 }
 
@@ -181,6 +213,7 @@ private struct SetupProgressRow: View {
   let title: String
   let symbol: String
   let state: State
+  var detail: String? = nil
 
   var body: some View {
     HStack(spacing: 14) {
@@ -189,9 +222,18 @@ private struct SetupProgressRow: View {
         .foregroundStyle(symbolColor)
         .frame(width: 22)
 
-      Text(title)
-        .font(.body.weight(state == .active ? .semibold : .regular))
-        .foregroundStyle(state == .pending ? Color.secondary : Color.primary)
+      VStack(alignment: .leading, spacing: 5) {
+        Text(title)
+          .font(.body.weight(state == .active ? .semibold : .regular))
+          .foregroundStyle(state == .pending ? Color.secondary : Color.primary)
+
+        if let detail {
+          Text(detail)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
 
       Spacer()
     }
@@ -213,5 +255,5 @@ private struct SetupProgressRow: View {
 #Preview("Onboarding") {
   MacOnboardingView(onComplete: {}, onDismiss: {})
     .environmentObject(FoqosFilterManager())
-    .frame(width: 520, height: 540)
+    .frame(width: 520, height: 620)
 }

--- a/FoqosMac/MacOnboardingView.swift
+++ b/FoqosMac/MacOnboardingView.swift
@@ -119,8 +119,8 @@ struct MacOnboardingView: View {
     }
 
     return """
-      Choose By Category, open Network Extensions, then turn on Foqos Website Filter. Return to \
-      Foqos when it is enabled.
+      Scroll down to Extensions, choose By Category, open Network Extensions, then turn on Foqos \
+      Website Filter. Return to Foqos when it is enabled.
       """
   }
 

--- a/FoqosMac/MenuBarContentView.swift
+++ b/FoqosMac/MenuBarContentView.swift
@@ -17,8 +17,12 @@ struct MenuBarContentView: View {
       Divider()
 
       footer
+
+      actions
     }
-    .padding(16)
+    .padding(.horizontal, 16)
+    .padding(.top, 16)
+    .padding(.bottom, 8)
     .frame(width: 360)
     .onAppear {
       filterManager.refreshStatus()
@@ -47,35 +51,6 @@ struct MenuBarContentView: View {
       }
 
       Spacer()
-
-      Button {
-        controller.refreshFromCloud()
-        filterManager.refreshStatus()
-      } label: {
-        Image(systemName: "arrow.clockwise")
-      }
-      .buttonStyle(.borderless)
-      .help("Refresh Foqos status")
-      .accessibilityLabel("Refresh Foqos status")
-
-      Button {
-        updaterController.checkForUpdates()
-      } label: {
-        Image(systemName: "arrow.down.circle")
-      }
-      .buttonStyle(.borderless)
-      .disabled(!updaterController.isConfigured)
-      .help(updaterHelpText)
-      .accessibilityLabel("Check for updates")
-
-      Button {
-        controller.quit()
-      } label: {
-        Image(systemName: "power")
-      }
-      .buttonStyle(.borderless)
-      .help("Quit Foqos")
-      .accessibilityLabel("Quit Foqos")
     }
   }
 
@@ -124,8 +99,31 @@ struct MenuBarContentView: View {
           }
         }
       }
-
     }
+  }
+
+  private var actions: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      MenuActionItem(
+        title: "Check for Updates",
+        isEnabled: updaterController.isConfigured
+      ) {
+        updaterController.checkForUpdates()
+      }
+      .help(updaterHelpText)
+
+      MenuActionItem(title: "Refresh State") {
+        controller.refreshFromCloud()
+        filterManager.refreshStatus()
+      }
+      .help("Refresh Foqos state")
+
+      MenuActionItem(title: "Quit Foqos") {
+        controller.quit()
+      }
+      .help("Quit Foqos")
+    }
+    .padding(.horizontal, -8)
   }
 
   private var updaterHelpText: String {
@@ -171,7 +169,7 @@ struct MenuBarContentView: View {
       return "checkmark.circle.fill"
     case .failed:
       return "xmark.circle.fill"
-    case .installing:
+    case .activatingExtension, .configuringFilter:
       return "arrow.triangle.2.circlepath.circle.fill"
     case .requiresRestart:
       return "arrow.clockwise.circle.fill"
@@ -182,16 +180,18 @@ struct MenuBarContentView: View {
 
   private var filterStatusTitle: String {
     switch filterManager.status {
+    case .activatingExtension:
+      return "Installing website blocking"
     case .approvalRequired:
       return "Approval required"
+    case .configuringFilter:
+      return "Waiting for filter permission"
     case .disabled:
       return "Website blocking is off"
     case .enabled:
       return "Website blocking is ready"
     case .failed:
       return "Website blocking error"
-    case .installing:
-      return "Setting up website blocking"
     case .notConfigured:
       return "Website blocking needs setup"
     case .requiresRestart:
@@ -227,7 +227,7 @@ struct MenuBarContentView: View {
       return .green
     case .failed:
       return .red
-    case .installing:
+    case .activatingExtension, .configuringFilter:
       return .blue
     default:
       return .orange
@@ -236,6 +236,42 @@ struct MenuBarContentView: View {
 
   private var emptyDomainMessage: String {
     "No blocked websites are active."
+  }
+}
+
+private struct MenuActionItem: View {
+  let title: String
+  var isEnabled = true
+  let action: () -> Void
+
+  @State private var isHovered = false
+
+  var body: some View {
+    Button(action: action) {
+      Text(title)
+        .font(.callout)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(foregroundColor)
+    .background {
+      RoundedRectangle(cornerRadius: 5, style: .continuous)
+        .fill(isHovered && isEnabled ? Color.accentColor : Color.clear)
+    }
+    .contentShape(Rectangle())
+    .disabled(!isEnabled)
+    .onHover { isHovered = $0 }
+  }
+
+  private var foregroundColor: Color {
+    if !isEnabled {
+      return .secondary
+    }
+
+    return isHovered ? .white : .primary
   }
 }
 


### PR DESCRIPTION
## Summary

- separate system-extension approval from the network-filter permission step
- open Login Items & Extensions directly and explain where to scroll for Network Extensions
- clarify the ordered setup states and permission guidance throughout the Mac app
- replace icon-only menu actions with full-width, hoverable menu rows

## Validation

- make mac-build
- make mac-test
- swift-format lint on all modified Mac files

Related to #473