### PR TITLE
Improve strategy setup and reusable start settings

### DIFF
--- a/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
@@ -25,8 +25,16 @@ final class BlockedProfileDraft: ObservableObject {
   @Published var physicalUnblockItems: [PhysicalUnblockItem]
   @Published var schedule: BlockedProfileSchedule
   @Published var selectedActivity: FamilyActivitySelection
+  @Published var strategyData: Data?
   @Published var selectedStrategy: BlockingStrategy? {
     didSet {
+      let oldSettingsKind = StrategyStartSettingsKind(strategy: oldValue)
+      let newSettingsKind = StrategyStartSettingsKind(strategy: selectedStrategy)
+
+      if newSettingsKind == nil || oldSettingsKind != newSettingsKind {
+        strategyData = nil
+      }
+
       enforceStrategyBreaksPolicy()
     }
   }
@@ -55,6 +63,7 @@ final class BlockedProfileDraft: ObservableObject {
     customReminderMessage = profile?.customReminderMessage ?? ""
     domains = profile?.domains ?? []
     physicalUnblockItems = profile?.physicalUnblockItems ?? []
+    strategyData = nil
     schedule =
       profile?.schedule
       ?? BlockedProfileSchedule(
@@ -71,6 +80,9 @@ final class BlockedProfileDraft: ObservableObject {
     } else {
       selectedStrategy = NFCBlockingStrategy()
     }
+
+    // Restore persisted settings after the strategy observer has handled initial selection.
+    strategyData = profile?.strategyData
 
     enforceStrategyBreaksPolicy()
   }
@@ -102,6 +114,7 @@ final class BlockedProfileDraft: ObservableObject {
         name: name,
         selection: selectedActivity,
         blockingStrategyId: selectedStrategy?.getIdentifier(),
+        strategyData: .some(strategyData),
         enableLiveActivity: enableLiveActivity,
         reminderTime: reminderTimeSeconds,
         customReminderMessage: customReminderMessage,
@@ -131,6 +144,7 @@ final class BlockedProfileDraft: ObservableObject {
       name: name,
       selection: selectedActivity,
       blockingStrategyId: selectedStrategy?.getIdentifier() ?? NFCBlockingStrategy.id,
+      strategyData: strategyData,
       enableLiveActivity: enableLiveActivity,
       reminderTimeInSeconds: reminderTimeSeconds,
       customReminderMessage: customReminderMessage,

--- a/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
@@ -26,6 +26,7 @@ final class BlockedProfileDraft: ObservableObject {
   @Published var schedule: BlockedProfileSchedule
   @Published var selectedActivity: FamilyActivitySelection
   @Published var strategyData: Data?
+  @Published var askForStartSettings: Bool
   @Published var selectedStrategy: BlockingStrategy? {
     didSet {
       let oldSettingsKind = StrategyStartSettingsKind(strategy: oldValue)
@@ -33,6 +34,7 @@ final class BlockedProfileDraft: ObservableObject {
 
       if newSettingsKind == nil || oldSettingsKind != newSettingsKind {
         strategyData = nil
+        askForStartSettings = true
       }
 
       enforceStrategyBreaksPolicy()
@@ -64,6 +66,7 @@ final class BlockedProfileDraft: ObservableObject {
     domains = profile?.domains ?? []
     physicalUnblockItems = profile?.physicalUnblockItems ?? []
     strategyData = nil
+    askForStartSettings = true
     schedule =
       profile?.schedule
       ?? BlockedProfileSchedule(
@@ -83,6 +86,7 @@ final class BlockedProfileDraft: ObservableObject {
 
     // Restore persisted settings after the strategy observer has handled initial selection.
     strategyData = profile?.strategyData
+    askForStartSettings = profile?.askForStartSettings ?? true
 
     enforceStrategyBreaksPolicy()
   }
@@ -99,6 +103,7 @@ final class BlockedProfileDraft: ObservableObject {
     existingProfile: BlockedProfiles?,
     in context: ModelContext
   ) throws -> BlockedProfiles {
+    ensureSavedStartSettings()
     schedule.updatedAt = Date()
 
     let reminderTimeSeconds: UInt32? =
@@ -115,6 +120,7 @@ final class BlockedProfileDraft: ObservableObject {
         selection: selectedActivity,
         blockingStrategyId: selectedStrategy?.getIdentifier(),
         strategyData: .some(strategyData),
+        askForStartSettings: askForStartSettings,
         enableLiveActivity: enableLiveActivity,
         reminderTime: reminderTimeSeconds,
         customReminderMessage: customReminderMessage,
@@ -145,6 +151,7 @@ final class BlockedProfileDraft: ObservableObject {
       selection: selectedActivity,
       blockingStrategyId: selectedStrategy?.getIdentifier() ?? NFCBlockingStrategy.id,
       strategyData: strategyData,
+      askForStartSettings: askForStartSettings,
       enableLiveActivity: enableLiveActivity,
       reminderTimeInSeconds: reminderTimeSeconds,
       customReminderMessage: customReminderMessage,
@@ -176,5 +183,15 @@ final class BlockedProfileDraft: ObservableObject {
 
     enableBreaks = false
     allowMultipleBreaks = false
+  }
+
+  private func ensureSavedStartSettings() {
+    guard !askForStartSettings, strategyData == nil,
+      let settingsKind = StrategyStartSettingsKind(strategy: selectedStrategy)
+    else {
+      return
+    }
+
+    strategyData = settingsKind.defaultData
   }
 }

--- a/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
@@ -282,9 +282,14 @@ struct BlockedProfileScheduleSection: View {
 }
 
 struct BlockedProfileBreaksFields: View {
+  @EnvironmentObject private var themeManager: ThemeManager
+
   @ObservedObject var draft: BlockedProfileDraft
   var disabled: Bool
   var showsSeparators: Bool = false
+
+  private let minimumBreakDurationInMinutes = 5
+  private let maximumBreakDurationInMinutes = 60
 
   @ViewBuilder
   var body: some View {
@@ -321,13 +326,42 @@ struct BlockedProfileBreaksFields: View {
   }
 
   private var breakDurationPicker: some View {
-    Picker("Break Duration", selection: $draft.breakTimeInMinutes) {
-      Text("5 minutes").tag(5)
-      Text("10 minutes").tag(10)
-      Text("15 minutes").tag(15)
-      Text("30 minutes").tag(30)
+    VStack(alignment: .leading, spacing: 10) {
+      HStack {
+        Text("Break Duration")
+
+        Spacer()
+
+        Text(DateFormatters.formatMinutes(draft.breakTimeInMinutes))
+          .fontWeight(.semibold)
+          .foregroundStyle(.secondary)
+          .contentTransition(.numericText())
+      }
+
+      Slider(
+        value: breakDurationBinding,
+        in: Double(minimumBreakDurationInMinutes)...Double(maximumBreakDurationInMinutes),
+        step: 5
+      )
+      .tint(themeManager.themeColor)
+      .accessibilityValue(DateFormatters.formatMinutes(draft.breakTimeInMinutes))
+
+      HStack {
+        Text("5m")
+        Spacer()
+        Text("1h")
+      }
+      .font(.caption2)
+      .foregroundStyle(.secondary)
     }
     .disabled(disabled)
+  }
+
+  private var breakDurationBinding: Binding<Double> {
+    Binding(
+      get: { Double(draft.breakTimeInMinutes) },
+      set: { draft.breakTimeInMinutes = Int($0) }
+    )
   }
 }
 

--- a/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
@@ -104,11 +104,16 @@ struct BlockedProfileStrategySection: View {
           }
         }
         .disabled(disabled)
+
+        CustomToggle(
+          title: "Ask Me Every Time",
+          description: "Turn off to use the saved settings automatically.",
+          isOn: $draft.askForStartSettings,
+          isDisabled: disabled
+        )
       }
     } header: {
       Text("Blocking Strategy")
-    } footer: {
-      Text("Choose how this profile starts and stops.")
     }
   }
 }

--- a/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
@@ -73,9 +73,13 @@ struct BlockedProfileStrategyFields: View {
 }
 
 struct BlockedProfileStrategySection: View {
+  @EnvironmentObject private var themeManager: ThemeManager
+
   @ObservedObject var draft: BlockedProfileDraft
   @Binding var showingStrategyPicker: Bool
   var disabled: Bool
+  var showsStartSettings: Bool = false
+  var onUpdateStartSettings: ((StrategyStartSettingsKind) -> Void)?
 
   var body: some View {
     Section {
@@ -84,6 +88,23 @@ struct BlockedProfileStrategySection: View {
         showingStrategyPicker: $showingStrategyPicker,
         disabled: disabled
       )
+
+      if showsStartSettings,
+        let settingsKind = StrategyStartSettingsKind(strategy: draft.selectedStrategy)
+      {
+        Button {
+          onUpdateStartSettings?(settingsKind)
+        } label: {
+          HStack {
+            Text("Update Start Settings")
+              .foregroundStyle(themeManager.themeColor)
+            Spacer()
+            Image(systemName: "chevron.right")
+              .foregroundStyle(.secondary)
+          }
+        }
+        .disabled(disabled)
+      }
     } header: {
       Text("Blocking Strategy")
     } footer: {

--- a/Foqos/Components/Strategy/PauseDurationView.swift
+++ b/Foqos/Components/Strategy/PauseDurationView.swift
@@ -7,10 +7,11 @@ struct PauseDurationView: View {
   let profileName: String
   var title: String = "Pause Duration"
   var description: String? = nil
+  let actionTitle: String
   let onDurationSelected: (Int) -> Void
 
   // State for slider-based duration selection
-  @State private var durationMinutes: Double = 15  // Default 15 minutes
+  @State private var durationMinutes: Double
   @State private var isSliding = false
 
   // Constants - max 1 hour for pause duration
@@ -21,6 +22,22 @@ struct PauseDurationView: View {
   // Common snap points (in minutes)
   private let snapPoints: [Double] = [5, 10, 15, 20, 30, 45, 60]
   private let snapThreshold: Double = 3  // How close to snap (in minutes)
+
+  init(
+    profileName: String,
+    title: String = "Pause Duration",
+    description: String? = nil,
+    initialDurationMinutes: Int = StrategyPauseTimerData.defaultPauseDurationInMinutes,
+    actionTitle: String = "Start Blocking",
+    onDurationSelected: @escaping (Int) -> Void
+  ) {
+    self.profileName = profileName
+    self.title = title
+    self.description = description
+    self.actionTitle = actionTitle
+    self.onDurationSelected = onDurationSelected
+    _durationMinutes = State(initialValue: Double(initialDurationMinutes))
+  }
 
   var body: some View {
     VStack(spacing: 32) {
@@ -46,7 +63,7 @@ struct PauseDurationView: View {
 
       // Confirm button
       ActionButton(
-        title: "Start Blocking",
+        title: actionTitle,
         backgroundColor: themeManager.themeColor,
         iconName: "checkmark.circle.fill"
       ) {

--- a/Foqos/Components/Strategy/SoftUnblockConfigurationView.swift
+++ b/Foqos/Components/Strategy/SoftUnblockConfigurationView.swift
@@ -5,6 +5,7 @@ struct SoftUnblockConfigurationView: View {
   @EnvironmentObject private var themeManager: ThemeManager
 
   let profileName: String
+  let actionTitle: String
   let onStart: (SoftUnblockStrategyData) -> Void
 
   @State private var maximumUnblockCount: Int
@@ -14,9 +15,11 @@ struct SoftUnblockConfigurationView: View {
   init(
     profileName: String,
     initialConfiguration: SoftUnblockStrategyData,
+    actionTitle: String = "Start Blocking",
     onStart: @escaping (SoftUnblockStrategyData) -> Void
   ) {
     self.profileName = profileName
+    self.actionTitle = actionTitle
     self.onStart = onStart
     _maximumUnblockCount = State(initialValue: initialConfiguration.maximumUnblockCount)
     _accessDurationInMinutes = State(
@@ -134,7 +137,7 @@ struct SoftUnblockConfigurationView: View {
 
   private var startButton: some View {
     ActionButton(
-      title: "Start Blocking",
+      title: actionTitle,
       backgroundColor: themeManager.themeColor,
       iconName: "checkmark.circle.fill"
     ) {

--- a/Foqos/Components/Strategy/SoftUnblockConfigurationView.swift
+++ b/Foqos/Components/Strategy/SoftUnblockConfigurationView.swift
@@ -11,6 +11,7 @@ struct SoftUnblockConfigurationView: View {
   @State private var maximumUnblockCount: Int
   @State private var accessDurationInMinutes: Int
   @State private var allowanceResetIntervalInHours: Int?
+  @State private var lastAllowanceResetIntervalInHours: Int
 
   init(
     profileName: String,
@@ -27,6 +28,10 @@ struct SoftUnblockConfigurationView: View {
     )
     _allowanceResetIntervalInHours = State(
       initialValue: initialConfiguration.allowanceResetIntervalInHours
+    )
+    _lastAllowanceResetIntervalInHours = State(
+      initialValue: initialConfiguration.allowanceResetIntervalInHours
+        ?? SoftUnblockStrategyData.defaultEnabledAllowanceResetIntervalInHours
     )
   }
 
@@ -96,17 +101,39 @@ struct SoftUnblockConfigurationView: View {
             }
 
             VStack(alignment: .leading, spacing: 12) {
-              Text("Reset Opens")
-                .font(.headline)
+              HStack {
+                Text("Reset Opens")
+                  .font(.headline)
 
-              Picker("Reset Opens", selection: $allowanceResetIntervalInHours) {
-                Text("Never").tag(Int?.none)
-                ForEach(SoftUnblockStrategyData.allowanceResetIntervalsInHours, id: \.self) {
-                  hours in
-                  Text("\(hours)h").tag(Int?.some(hours))
-                }
+                Spacer()
+
+                Toggle("Reset Opens", isOn: resetEnabledBinding)
+                  .labelsHidden()
+                  .tint(themeManager.themeColor)
               }
-              .pickerStyle(.segmented)
+
+              if allowanceResetIntervalInHours != nil {
+                Text(formattedResetInterval)
+                  .font(.system(size: 40, weight: .bold, design: .rounded))
+                  .contentTransition(.numericText())
+
+                Slider(
+                  value: resetIntervalBinding,
+                  in: resetIntervalRange,
+                  step: 1
+                )
+                .tint(themeManager.themeColor)
+                .sensoryFeedback(.selection, trigger: allowanceResetIntervalInHours)
+                .accessibilityValue(formattedResetInterval)
+
+                HStack {
+                  Text("1h")
+                  Spacer()
+                  Text("24h")
+                }
+                .font(.caption2)
+                .foregroundColor(.secondary)
+              }
 
               Text(resetDescription)
                 .font(.caption)
@@ -159,13 +186,47 @@ struct SoftUnblockConfigurationView: View {
     )
   }
 
+  private var resetEnabledBinding: Binding<Bool> {
+    Binding(
+      get: { allowanceResetIntervalInHours != nil },
+      set: { isEnabled in
+        allowanceResetIntervalInHours = isEnabled ? lastAllowanceResetIntervalInHours : nil
+      }
+    )
+  }
+
+  private var resetIntervalBinding: Binding<Double> {
+    Binding(
+      get: { Double(allowanceResetIntervalInHours ?? lastAllowanceResetIntervalInHours) },
+      set: { value in
+        let interval = Int(value)
+        allowanceResetIntervalInHours = interval
+        lastAllowanceResetIntervalInHours = interval
+      }
+    )
+  }
+
+  private var resetIntervalRange: ClosedRange<Double> {
+    let range = SoftUnblockStrategyData.allowanceResetIntervalRangeInHours
+    return Double(range.lowerBound)...Double(range.upperBound)
+  }
+
   private var formattedDuration: String {
     accessDurationInMinutes == 60 ? "1 hour" : "\(accessDurationInMinutes) minutes"
+  }
+
+  private var formattedResetInterval: String {
+    let interval = allowanceResetIntervalInHours ?? lastAllowanceResetIntervalInHours
+    return interval == 1 ? "1 hour" : "\(interval) hours"
   }
 
   private var resetDescription: String {
     guard let allowanceResetIntervalInHours else {
       return "Your opens do not reset during this session."
+    }
+
+    if allowanceResetIntervalInHours == 1 {
+      return "You get all your opens back every hour."
     }
 
     return "You get all your opens back every \(allowanceResetIntervalInHours) hours."

--- a/Foqos/Components/Strategy/SoftUnblockConfigurationView.swift
+++ b/Foqos/Components/Strategy/SoftUnblockConfigurationView.swift
@@ -53,6 +53,10 @@ struct SoftUnblockConfigurationView: View {
               Text("Allowed Opens")
                 .font(.headline)
 
+              Text("Each time you open a blocked app or category, it uses one.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
               Stepper(
                 value: $maximumUnblockCount,
                 in: SoftUnblockStrategyData.unblockCountRange
@@ -67,10 +71,6 @@ struct SoftUnblockConfigurationView: View {
                 }
               }
               .sensoryFeedback(.selection, trigger: maximumUnblockCount)
-
-              Text("Each time you open a blocked app or category, it uses one.")
-                .font(.caption)
-                .foregroundColor(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 12) {
@@ -112,6 +112,10 @@ struct SoftUnblockConfigurationView: View {
                   .tint(themeManager.themeColor)
               }
 
+              Text(resetDescription)
+                .font(.caption)
+                .foregroundColor(.secondary)
+
               if allowanceResetIntervalInHours != nil {
                 Text(formattedResetInterval)
                   .font(.system(size: 40, weight: .bold, design: .rounded))
@@ -134,10 +138,6 @@ struct SoftUnblockConfigurationView: View {
                 .font(.caption2)
                 .foregroundColor(.secondary)
               }
-
-              Text(resetDescription)
-                .font(.caption)
-                .foregroundColor(.secondary)
             }
           }
           .padding(.horizontal, 24)

--- a/Foqos/Components/Strategy/StrategyStartSettingsView.swift
+++ b/Foqos/Components/Strategy/StrategyStartSettingsView.swift
@@ -41,6 +41,21 @@ enum StrategyStartSettingsKind: String, Identifiable {
       return [.medium, .large]
     }
   }
+
+  var defaultData: Data? {
+    switch self {
+    case .timer:
+      return StrategyTimerData.toData(from: .defaultConfiguration)
+    case .pauseTimer:
+      return StrategyPauseTimerData.toData(
+        from: StrategyPauseTimerData(
+          pauseDurationInMinutes: StrategyPauseTimerData.defaultPauseDurationInMinutes
+        )
+      )
+    case .temporaryAccess:
+      return SoftUnblockStrategyData.encode(SoftUnblockStrategyData.decode(nil))
+    }
+  }
 }
 
 struct StrategyStartSettingsView: View {

--- a/Foqos/Components/Strategy/StrategyStartSettingsView.swift
+++ b/Foqos/Components/Strategy/StrategyStartSettingsView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+enum StrategyStartSettingsKind: String, Identifiable {
+  case timer
+  case pauseTimer
+  case temporaryAccess
+
+  var id: String { rawValue }
+
+  init?(strategy: BlockingStrategy?) {
+    guard let strategy else {
+      return nil
+    }
+
+    if strategy.hasTimer {
+      self = .timer
+      return
+    }
+
+    if strategy.hasPauseMode {
+      self = .pauseTimer
+      return
+    }
+
+    let strategyId = strategy.getIdentifier()
+    if strategyId == NFCSoftUnblockBlockingStrategy.id
+      || strategyId == QRSoftUnblockBlockingStrategy.id
+    {
+      self = .temporaryAccess
+      return
+    }
+
+    return nil
+  }
+
+  var presentationDetents: Set<PresentationDetent> {
+    switch self {
+    case .temporaryAccess:
+      return [.large]
+    case .timer, .pauseTimer:
+      return [.medium, .large]
+    }
+  }
+}
+
+struct StrategyStartSettingsView: View {
+  let kind: StrategyStartSettingsKind
+  @ObservedObject var draft: BlockedProfileDraft
+
+  private var profileName: String {
+    draft.name.isEmpty ? "this profile" : draft.name
+  }
+
+  @ViewBuilder
+  var body: some View {
+    switch kind {
+    case .timer:
+      TimerDurationView(
+        profileName: profileName,
+        initialConfiguration: StrategyTimerData.decode(draft.strategyData),
+        actionTitle: "Save Settings"
+      ) { configuration in
+        draft.strategyData = StrategyTimerData.toData(from: configuration)
+      }
+
+    case .pauseTimer:
+      let configuration = StrategyPauseTimerData.toStrategyPauseTimerData(
+        from: draft.strategyData
+      )
+
+      PauseDurationView(
+        profileName: profileName,
+        initialDurationMinutes: configuration.pauseDurationInMinutes,
+        actionTitle: "Save Settings"
+      ) { durationInMinutes in
+        draft.strategyData = StrategyPauseTimerData.toData(
+          from: StrategyPauseTimerData(
+            pauseDurationInMinutes: durationInMinutes
+          )
+        )
+      }
+
+    case .temporaryAccess:
+      SoftUnblockConfigurationView(
+        profileName: profileName,
+        initialConfiguration: SoftUnblockStrategyData.decode(draft.strategyData),
+        actionTitle: "Save Settings"
+      ) { configuration in
+        draft.strategyData = SoftUnblockStrategyData.encode(configuration)
+      }
+    }
+  }
+}

--- a/Foqos/Components/Strategy/TimerDurationView.swift
+++ b/Foqos/Components/Strategy/TimerDurationView.swift
@@ -5,12 +5,13 @@ struct TimerDurationView: View {
   @Environment(\.dismiss) private var dismiss
 
   let profileName: String
+  let actionTitle: String
   let onDurationSelected: (StrategyTimerData) -> Void
 
   // State for slider-based duration selection
-  @State private var durationMinutes: Double = 60  // Default 1 hour
+  @State private var durationMinutes: Double
   @State private var isSliding = false
-  @State private var hideStopButton = false  // Toggle for hiding stop button
+  @State private var hideStopButton: Bool
 
   // Constants
   private let minMinutes: Double = 15
@@ -21,6 +22,19 @@ struct TimerDurationView: View {
   // Common snap points (in minutes)
   private let snapPoints: [Double] = [15, 30, 45, 60, 90, 120, 180, 240, 360, 480, 720, 1440]
   private let snapThreshold: Double = 10  // How close to snap (in minutes)
+
+  init(
+    profileName: String,
+    initialConfiguration: StrategyTimerData = .defaultConfiguration,
+    actionTitle: String = "Set Duration",
+    onDurationSelected: @escaping (StrategyTimerData) -> Void
+  ) {
+    self.profileName = profileName
+    self.actionTitle = actionTitle
+    self.onDurationSelected = onDurationSelected
+    _durationMinutes = State(initialValue: Double(initialConfiguration.durationInMinutes))
+    _hideStopButton = State(initialValue: initialConfiguration.hideStopButton)
+  }
 
   var body: some View {
     VStack(spacing: 32) {
@@ -49,7 +63,7 @@ struct TimerDurationView: View {
 
       // Confirm button
       ActionButton(
-        title: "Set Duration",
+        title: actionTitle,
         backgroundColor: themeManager.themeColor,
         iconName: "checkmark.circle.fill"
       ) {

--- a/Foqos/Components/Strategy/TimerDurationView.swift
+++ b/Foqos/Components/Strategy/TimerDurationView.swift
@@ -188,7 +188,7 @@ struct TimerDurationView: View {
   private var hideStopButtonToggle: some View {
     HStack(spacing: 12) {
       VStack(alignment: .leading, spacing: 2) {
-        Text("Hide Stop Button")
+        Text("Disable Stop Button")
           .font(.body)
           .fontWeight(.medium)
 

--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -13,6 +13,7 @@ class BlockedProfiles {
   var updatedAt: Date
   var blockingStrategyId: String?
   var strategyData: Data?
+  var askForStartSettings: Bool = true
   var order: Int = 0
 
   var enableLiveActivity: Bool = false
@@ -68,6 +69,10 @@ class BlockedProfiles {
     return StrategyManager.getStrategyFromId(id: strategyId).allowsTimedBreaks
   }
 
+  var shouldAskForStartSettings: Bool {
+    askForStartSettings || strategyData == nil
+  }
+
   // MARK: - Physical Unblock Helpers
 
   /// Checks if a specific NFC tag or QR code can unblock this profile
@@ -101,6 +106,7 @@ class BlockedProfiles {
     updatedAt: Date = Date(),
     blockingStrategyId: String = NFCBlockingStrategy.id,
     strategyData: Data? = nil,
+    askForStartSettings: Bool = true,
     enableLiveActivity: Bool = false,
     reminderTimeInSeconds: UInt32? = nil,
     customReminderMessage: String? = nil,
@@ -128,6 +134,7 @@ class BlockedProfiles {
     self.updatedAt = updatedAt
     self.blockingStrategyId = blockingStrategyId
     self.strategyData = strategyData
+    self.askForStartSettings = askForStartSettings
     self.order = order
 
     self.enableLiveActivity = enableLiveActivity
@@ -202,6 +209,7 @@ class BlockedProfiles {
     selection: FamilyActivitySelection? = nil,
     blockingStrategyId: String? = nil,
     strategyData: Data?? = nil,
+    askForStartSettings: Bool? = nil,
     enableLiveActivity: Bool? = nil,
     reminderTime: UInt32? = nil,
     customReminderMessage: String? = nil,
@@ -251,6 +259,10 @@ class BlockedProfiles {
 
     if let strategyData {
       profile.strategyData = strategyData
+    }
+
+    if let newAskForStartSettings = askForStartSettings {
+      profile.askForStartSettings = newAskForStartSettings
     }
 
     if let newEnableLiveActivity = enableLiveActivity {
@@ -438,6 +450,7 @@ class BlockedProfiles {
     selection: FamilyActivitySelection = FamilyActivitySelection(),
     blockingStrategyId: String = NFCBlockingStrategy.id,
     strategyData: Data? = nil,
+    askForStartSettings: Bool = true,
     enableLiveActivity: Bool = false,
     reminderTimeInSeconds: UInt32? = nil,
     customReminderMessage: String = "",
@@ -464,6 +477,7 @@ class BlockedProfiles {
       selectedActivity: selection,
       blockingStrategyId: blockingStrategyId,
       strategyData: strategyData,
+      askForStartSettings: askForStartSettings,
       enableLiveActivity: enableLiveActivity,
       reminderTimeInSeconds: reminderTimeInSeconds,
       customReminderMessage: customReminderMessage,
@@ -507,6 +521,7 @@ class BlockedProfiles {
       selectedActivity: source.selectedActivity,
       blockingStrategyId: source.blockingStrategyId ?? NFCBlockingStrategy.id,
       strategyData: source.strategyData,
+      askForStartSettings: source.askForStartSettings,
       enableLiveActivity: source.enableLiveActivity,
       reminderTimeInSeconds: source.reminderTimeInSeconds,
       customReminderMessage: source.customReminderMessage,

--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -201,7 +201,7 @@ class BlockedProfiles {
     name: String? = nil,
     selection: FamilyActivitySelection? = nil,
     blockingStrategyId: String? = nil,
-    strategyData: Data? = nil,
+    strategyData: Data?? = nil,
     enableLiveActivity: Bool? = nil,
     reminderTime: UInt32? = nil,
     customReminderMessage: String? = nil,
@@ -249,8 +249,8 @@ class BlockedProfiles {
       profile.blockingStrategyId = newStrategyId
     }
 
-    if let newStrategyData = strategyData {
-      profile.strategyData = newStrategyData
+    if let strategyData {
+      profile.strategyData = strategyData
     }
 
     if let newEnableLiveActivity = enableLiveActivity {

--- a/Foqos/Models/SoftUnblockGrant.swift
+++ b/Foqos/Models/SoftUnblockGrant.swift
@@ -31,7 +31,7 @@ struct SoftUnblockGrant: Codable, Equatable, Identifiable {
 
 struct SoftUnblockSessionState: Codable, Equatable {
   static let maximumUnblockCountRange = 1...10
-  static let allowanceResetIntervalsInHours = [6, 12, 24]
+  static let allowanceResetIntervalRangeInHours = 1...24
 
   let sessionId: String
   let profileId: UUID

--- a/Foqos/Models/Strategies/BlockingStrategy.swift
+++ b/Foqos/Models/Strategies/BlockingStrategy.swift
@@ -75,7 +75,7 @@ enum BlockingStrategyPickerCategory: String, CaseIterable {
     case .timers:
       return "Choose a duration first, then let the session end automatically."
     case .forever:
-      return "Sessions that keep going until you intentionally stop."
+      return "Flexible strategies for temporary access and timed pauses."
     case .moreOptions:
       return "Additional ways to control a focus session."
     }

--- a/Foqos/Models/Strategies/BlockingStrategy.swift
+++ b/Foqos/Models/Strategies/BlockingStrategy.swift
@@ -60,7 +60,7 @@ enum BlockingStrategyPickerCategory: String, CaseIterable {
     case .timers:
       return "Timers"
     case .forever:
-      return "Forever"
+      return "Advanced"
     case .moreOptions:
       return "More options"
     }

--- a/Foqos/Models/Strategies/Data/SoftUnblockStrategyData.swift
+++ b/Foqos/Models/Strategies/Data/SoftUnblockStrategyData.swift
@@ -4,10 +4,11 @@ struct SoftUnblockStrategyData: Codable, Equatable {
   static let defaultDurationInMinutes = 15
   static let defaultMaximumUnblockCount = 3
   static let defaultAllowanceResetIntervalInHours: Int? = nil
+  static let defaultEnabledAllowanceResetIntervalInHours = 6
   static let durationRange = 5...60
   static let unblockCountRange = SoftUnblockSessionState.maximumUnblockCountRange
-  static let allowanceResetIntervalsInHours =
-    SoftUnblockSessionState.allowanceResetIntervalsInHours
+  static let allowanceResetIntervalRangeInHours =
+    SoftUnblockSessionState.allowanceResetIntervalRangeInHours
 
   var accessDurationInMinutes: Int
   var maximumUnblockCount: Int
@@ -42,7 +43,7 @@ struct SoftUnblockStrategyData: Codable, Equatable {
         Self.unblockCountRange.upperBound
       ),
       allowanceResetIntervalInHours: allowanceResetIntervalInHours.flatMap { interval in
-        Self.allowanceResetIntervalsInHours.contains(interval) ? interval : nil
+        Self.allowanceResetIntervalRangeInHours.contains(interval) ? interval : nil
       }
     )
   }

--- a/Foqos/Models/Strategies/Data/StrategyTimerData.swift
+++ b/Foqos/Models/Strategies/Data/StrategyTimerData.swift
@@ -1,8 +1,25 @@
 import SwiftUI
 
 struct StrategyTimerData: Codable {
+  static let defaultDurationInMinutes = 60
+
   var durationInMinutes: Int
   var hideStopButton: Bool
+
+  static var defaultConfiguration: StrategyTimerData {
+    StrategyTimerData(
+      durationInMinutes: defaultDurationInMinutes,
+      hideStopButton: false
+    )
+  }
+
+  static func decode(_ data: Data?) -> StrategyTimerData {
+    guard let data else {
+      return defaultConfiguration
+    }
+
+    return toStrategyTimerData(from: data)
+  }
 
   static func toStrategyTimerData(from data: Data) -> StrategyTimerData {
     do {

--- a/Foqos/Models/Strategies/NFCPauseTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCPauseTimerBlockingStrategy.swift
@@ -29,8 +29,13 @@ class NFCPauseTimerBlockingStrategy: BlockingStrategy {
     profile: BlockedProfiles,
     forceStart: Bool?
   ) -> (any View)? {
+    let pauseTimerData = StrategyPauseTimerData.toStrategyPauseTimerData(
+      from: profile.strategyData
+    )
+
     return PauseDurationView(
       profileName: profile.name,
+      initialDurationMinutes: pauseTimerData.pauseDurationInMinutes,
       onDurationSelected: { pauseDurationMinutes in
         // Save the pause duration to the profile
         let pauseTimerData = StrategyPauseTimerData(

--- a/Foqos/Models/Strategies/NFCPauseTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCPauseTimerBlockingStrategy.swift
@@ -29,6 +29,15 @@ class NFCPauseTimerBlockingStrategy: BlockingStrategy {
     profile: BlockedProfiles,
     forceStart: Bool?
   ) -> (any View)? {
+    if !profile.shouldAskForStartSettings {
+      startPauseTimerSession(
+        context: context,
+        profile: profile,
+        forceStart: forceStart ?? false
+      )
+      return nil
+    }
+
     let pauseTimerData = StrategyPauseTimerData.toStrategyPauseTimerData(
       from: profile.strategyData
     )
@@ -47,19 +56,30 @@ class NFCPauseTimerBlockingStrategy: BlockingStrategy {
           try? context.save()
         }
 
-        // Immediately start blocking (like QRManualBlockingStrategy)
-        self.appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
-
-        let activeSession = BlockedProfileSession.createSession(
-          in: context,
-          withTag: NFCPauseTimerBlockingStrategy.id,
-          withProfile: profile,
+        self.startPauseTimerSession(
+          context: context,
+          profile: profile,
           forceStart: forceStart ?? false
         )
-
-        self.onSessionCreation?(.started(activeSession))
       }
     )
+  }
+
+  private func startPauseTimerSession(
+    context: ModelContext,
+    profile: BlockedProfiles,
+    forceStart: Bool
+  ) {
+    appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
+
+    let activeSession = BlockedProfileSession.createSession(
+      in: context,
+      withTag: Self.id,
+      withProfile: profile,
+      forceStart: forceStart
+    )
+
+    onSessionCreation?(.started(activeSession))
   }
 
   func stopBlocking(

--- a/Foqos/Models/Strategies/NFCSoftUnblockBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCSoftUnblockBlockingStrategy.swift
@@ -32,7 +32,16 @@ final class NFCSoftUnblockBlockingStrategy: BlockingStrategy {
     profile: BlockedProfiles,
     forceStart: Bool?
   ) -> (any View)? {
-    SoftUnblockConfigurationView(
+    if !profile.shouldAskForStartSettings {
+      startSession(
+        context: context,
+        profile: profile,
+        forceStart: forceStart ?? false
+      )
+      return nil
+    }
+
+    return SoftUnblockConfigurationView(
       profileName: profile.name,
       initialConfiguration: SoftUnblockStrategyData.decode(profile.strategyData),
       onStart: { configuration in
@@ -53,17 +62,29 @@ final class NFCSoftUnblockBlockingStrategy: BlockingStrategy {
 
         BlockedProfiles.updateSnapshot(for: profile)
 
-        let activeSession = BlockedProfileSession.createSession(
-          in: context,
-          withTag: Self.id,
-          withProfile: profile,
+        self.startSession(
+          context: context,
+          profile: profile,
           forceStart: forceStart ?? false
         )
-
-        self.appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
-        self.onSessionCreation?(.started(activeSession))
       }
     )
+  }
+
+  private func startSession(
+    context: ModelContext,
+    profile: BlockedProfiles,
+    forceStart: Bool
+  ) {
+    let activeSession = BlockedProfileSession.createSession(
+      in: context,
+      withTag: Self.id,
+      withProfile: profile,
+      forceStart: forceStart
+    )
+
+    appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
+    onSessionCreation?(.started(activeSession))
   }
 
   func stopBlocking(

--- a/Foqos/Models/Strategies/NFCTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCTimerBlockingStrategy.swift
@@ -29,6 +29,15 @@ class NFCTimerBlockingStrategy: BlockingStrategy {
     profile: BlockedProfiles,
     forceStart: Bool?
   ) -> (any View)? {
+    if !profile.shouldAskForStartSettings {
+      startTimerSession(
+        context: context,
+        profile: profile,
+        forceStart: forceStart ?? false
+      )
+      return nil
+    }
+
     return TimerDurationView(
       profileName: profile.name,
       initialConfiguration: StrategyTimerData.decode(profile.strategyData),
@@ -42,18 +51,30 @@ class NFCTimerBlockingStrategy: BlockingStrategy {
           try? context.save()
         }
 
-        let activeSession = BlockedProfileSession.createSession(
-          in: context,
-          withTag: NFCTimerBlockingStrategy.id,
-          withProfile: profile,
+        self.startTimerSession(
+          context: context,
+          profile: profile,
           forceStart: forceStart ?? false
         )
-
-        DeviceActivityCenterUtil.startStrategyTimerActivity(for: profile)
-
-        self.onSessionCreation?(.started(activeSession))
       }
     )
+  }
+
+  private func startTimerSession(
+    context: ModelContext,
+    profile: BlockedProfiles,
+    forceStart: Bool
+  ) {
+    let activeSession = BlockedProfileSession.createSession(
+      in: context,
+      withTag: Self.id,
+      withProfile: profile,
+      forceStart: forceStart
+    )
+
+    DeviceActivityCenterUtil.startStrategyTimerActivity(for: profile)
+
+    onSessionCreation?(.started(activeSession))
   }
 
   func stopBlocking(

--- a/Foqos/Models/Strategies/NFCTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCTimerBlockingStrategy.swift
@@ -31,6 +31,7 @@ class NFCTimerBlockingStrategy: BlockingStrategy {
   ) -> (any View)? {
     return TimerDurationView(
       profileName: profile.name,
+      initialConfiguration: StrategyTimerData.decode(profile.strategyData),
       onDurationSelected: { duration in
         if let strategyTimerData = StrategyTimerData.toData(from: duration) {
           // Store the timer data so that its selected for the next time the profile is started

--- a/Foqos/Models/Strategies/QRPauseTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/QRPauseTimerBlockingStrategy.swift
@@ -29,8 +29,13 @@ class QRPauseTimerBlockingStrategy: BlockingStrategy {
     profile: BlockedProfiles,
     forceStart: Bool?
   ) -> (any View)? {
+    let pauseTimerData = StrategyPauseTimerData.toStrategyPauseTimerData(
+      from: profile.strategyData
+    )
+
     return PauseDurationView(
       profileName: profile.name,
+      initialDurationMinutes: pauseTimerData.pauseDurationInMinutes,
       onDurationSelected: { pauseDurationMinutes in
         // Save the pause duration to the profile
         let pauseTimerData = StrategyPauseTimerData(

--- a/Foqos/Models/Strategies/QRPauseTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/QRPauseTimerBlockingStrategy.swift
@@ -29,6 +29,15 @@ class QRPauseTimerBlockingStrategy: BlockingStrategy {
     profile: BlockedProfiles,
     forceStart: Bool?
   ) -> (any View)? {
+    if !profile.shouldAskForStartSettings {
+      startPauseTimerSession(
+        context: context,
+        profile: profile,
+        forceStart: forceStart ?? false
+      )
+      return nil
+    }
+
     let pauseTimerData = StrategyPauseTimerData.toStrategyPauseTimerData(
       from: profile.strategyData
     )
@@ -47,19 +56,30 @@ class QRPauseTimerBlockingStrategy: BlockingStrategy {
           try? context.save()
         }
 
-        // Immediately start blocking (like QRManualBlockingStrategy)
-        self.appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
-
-        let activeSession = BlockedProfileSession.createSession(
-          in: context,
-          withTag: QRPauseTimerBlockingStrategy.id,
-          withProfile: profile,
+        self.startPauseTimerSession(
+          context: context,
+          profile: profile,
           forceStart: forceStart ?? false
         )
-
-        self.onSessionCreation?(.started(activeSession))
       }
     )
+  }
+
+  private func startPauseTimerSession(
+    context: ModelContext,
+    profile: BlockedProfiles,
+    forceStart: Bool
+  ) {
+    appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
+
+    let activeSession = BlockedProfileSession.createSession(
+      in: context,
+      withTag: Self.id,
+      withProfile: profile,
+      forceStart: forceStart
+    )
+
+    onSessionCreation?(.started(activeSession))
   }
 
   func stopBlocking(

--- a/Foqos/Models/Strategies/QRSoftUnblockBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/QRSoftUnblockBlockingStrategy.swift
@@ -31,7 +31,16 @@ final class QRSoftUnblockBlockingStrategy: BlockingStrategy {
     profile: BlockedProfiles,
     forceStart: Bool?
   ) -> (any View)? {
-    SoftUnblockConfigurationView(
+    if !profile.shouldAskForStartSettings {
+      startSession(
+        context: context,
+        profile: profile,
+        forceStart: forceStart ?? false
+      )
+      return nil
+    }
+
+    return SoftUnblockConfigurationView(
       profileName: profile.name,
       initialConfiguration: SoftUnblockStrategyData.decode(profile.strategyData),
       onStart: { configuration in
@@ -52,17 +61,29 @@ final class QRSoftUnblockBlockingStrategy: BlockingStrategy {
 
         BlockedProfiles.updateSnapshot(for: profile)
 
-        let activeSession = BlockedProfileSession.createSession(
-          in: context,
-          withTag: Self.id,
-          withProfile: profile,
+        self.startSession(
+          context: context,
+          profile: profile,
           forceStart: forceStart ?? false
         )
-
-        self.appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
-        self.onSessionCreation?(.started(activeSession))
       }
     )
+  }
+
+  private func startSession(
+    context: ModelContext,
+    profile: BlockedProfiles,
+    forceStart: Bool
+  ) {
+    let activeSession = BlockedProfileSession.createSession(
+      in: context,
+      withTag: Self.id,
+      withProfile: profile,
+      forceStart: forceStart
+    )
+
+    appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
+    onSessionCreation?(.started(activeSession))
   }
 
   func stopBlocking(

--- a/Foqos/Models/Strategies/QRTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/QRTimerBlockingStrategy.swift
@@ -30,6 +30,7 @@ class QRTimerBlockingStrategy: BlockingStrategy {
   ) -> (any View)? {
     return TimerDurationView(
       profileName: profile.name,
+      initialConfiguration: StrategyTimerData.decode(profile.strategyData),
       onDurationSelected: { duration in
         if let strategyTimerData = StrategyTimerData.toData(from: duration) {
           // Store the timer data so that its selected for the next time the profile is started

--- a/Foqos/Models/Strategies/QRTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/QRTimerBlockingStrategy.swift
@@ -28,6 +28,15 @@ class QRTimerBlockingStrategy: BlockingStrategy {
     profile: BlockedProfiles,
     forceStart: Bool?
   ) -> (any View)? {
+    if !profile.shouldAskForStartSettings {
+      startTimerSession(
+        context: context,
+        profile: profile,
+        forceStart: forceStart ?? false
+      )
+      return nil
+    }
+
     return TimerDurationView(
       profileName: profile.name,
       initialConfiguration: StrategyTimerData.decode(profile.strategyData),
@@ -41,18 +50,30 @@ class QRTimerBlockingStrategy: BlockingStrategy {
           try? context.save()
         }
 
-        let activeSession = BlockedProfileSession.createSession(
-          in: context,
-          withTag: QRTimerBlockingStrategy.id,
-          withProfile: profile,
+        self.startTimerSession(
+          context: context,
+          profile: profile,
           forceStart: forceStart ?? false
         )
-
-        DeviceActivityCenterUtil.startStrategyTimerActivity(for: profile)
-
-        self.onSessionCreation?(.started(activeSession))
       }
     )
+  }
+
+  private func startTimerSession(
+    context: ModelContext,
+    profile: BlockedProfiles,
+    forceStart: Bool
+  ) {
+    let activeSession = BlockedProfileSession.createSession(
+      in: context,
+      withTag: Self.id,
+      withProfile: profile,
+      forceStart: forceStart
+    )
+
+    DeviceActivityCenterUtil.startStrategyTimerActivity(for: profile)
+
+    onSessionCreation?(.started(activeSession))
   }
 
   func stopBlocking(

--- a/Foqos/Models/Strategies/ShortcutTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/ShortcutTimerBlockingStrategy.swift
@@ -28,8 +28,12 @@ class ShortcutTimerBlockingStrategy: BlockingStrategy {
     profile: BlockedProfiles,
     forceStart: Bool?
   ) -> (any View)? {
-    if forceStart == true {
-      return startTimerSession(context: context, profile: profile, forceStart: true)
+    if forceStart == true || !profile.shouldAskForStartSettings {
+      return startTimerSession(
+        context: context,
+        profile: profile,
+        forceStart: forceStart ?? false
+      )
     }
 
     return TimerDurationView(

--- a/Foqos/Models/Strategies/ShortcutTimerBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/ShortcutTimerBlockingStrategy.swift
@@ -34,6 +34,7 @@ class ShortcutTimerBlockingStrategy: BlockingStrategy {
 
     return TimerDurationView(
       profileName: profile.name,
+      initialConfiguration: StrategyTimerData.decode(profile.strategyData),
       onDurationSelected: { duration in
         if let strategyTimerData = StrategyTimerData.toData(from: duration) {
           profile.strategyData = strategyTimerData

--- a/Foqos/Utils/DateFormatters.swift
+++ b/Foqos/Utils/DateFormatters.swift
@@ -31,7 +31,7 @@ enum DateFormatters {
   }
 
   static func formatMinutes(_ durationInMinutes: Int) -> String {
-    if durationInMinutes <= 60 {
+    if durationInMinutes < 60 {
       return "\(durationInMinutes) min"
     } else {
       let hours = durationInMinutes / 60

--- a/Foqos/Utils/SoftUnblockGrantStore.swift
+++ b/Foqos/Utils/SoftUnblockGrantStore.swift
@@ -201,7 +201,7 @@ enum SoftUnblockGrantStore {
 
   private static func normalizedResetInterval(_ interval: Int?) -> Int? {
     guard let interval,
-      SoftUnblockSessionState.allowanceResetIntervalsInHours.contains(interval)
+      SoftUnblockSessionState.allowanceResetIntervalRangeInHours.contains(interval)
     else {
       return nil
     }

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -41,6 +41,9 @@ struct BlockedProfileView: View {
   // Sheet for strategy picker
   @State private var showingStrategyPicker = false
 
+  // Sheet for strategy-specific start settings
+  @State private var startSettingsDestination: StrategyStartSettingsKind?
+
   // Alert management
   @State private var alertIdentifier: AlertIdentifier?
 
@@ -92,7 +95,11 @@ struct BlockedProfileView: View {
         BlockedProfileStrategySection(
           draft: draft,
           showingStrategyPicker: $showingStrategyPicker,
-          disabled: isBlocking
+          disabled: isBlocking,
+          showsStartSettings: isEditing,
+          onUpdateStartSettings: { settingsKind in
+            startSettingsDestination = settingsKind
+          }
         )
 
         BlockedProfileAppsSection(
@@ -220,6 +227,13 @@ struct BlockedProfileView: View {
           selectedStrategy: $draft.selectedStrategy,
           isPresented: $showingStrategyPicker
         )
+      }
+      .sheet(item: $startSettingsDestination) { settingsKind in
+        StrategyStartSettingsView(
+          kind: settingsKind,
+          draft: draft
+        )
+        .presentationDetents(settingsKind.presentationDetents)
       }
       .sheet(isPresented: $showingGeneratedQRCode) {
         if let profileToWrite = profile {


### PR DESCRIPTION
## What changed

This PR takes the parts of #466 that fit the current Foqos model without turning every suggestion into another strategy or setup requirement.

- Renames the `Forever` strategy category to `Advanced` and updates its description to reflect the temporary-access and timed-pause strategies it contains.
- Renames `Hide Stop Button` to `Disable Stop Button` so the consequence is clearer.
- Replaces the fixed break-duration picker with a themed slider in five-minute increments, from 5 minutes to 1 hour.
- Adds `Update Start Settings` to profile editing for Timer, Pause Timer, and Temporary Access strategies. It reuses the same configuration views shown at session start and persists the result with the profile.
- Adds an `Ask Me Every Time` preference. It defaults to on, preserving the existing start flow. When turned off, the profile starts with its saved settings instead of prompting again.
- Keeps settings when switching between compatible variants, such as NFC Timer and QR Timer, and clears them when the new strategy uses a different data shape. Incompatible switches also turn `Ask Me Every Time` back on.
- Fixes an initialization-order bug that caused the profile editor to lose saved strategy data and show defaults that did not match the start screen.
- Replaces the fixed Temporary Access reset choices with a themed slider from 1 to 24 hours. Turning `Reset Opens` off still means `Never`, and existing `Never`, 6-hour, 12-hour, and 24-hour settings keep their original meaning. Supporting descriptions now appear before the controls they explain. This addresses item 7 by removing the six-hour minimum.

## Decisions from #466 that are not included

- **NFC and QR strategies remain explicit.** A physical unlock entry is an optional allow-list for stopping a session, not the thing that determines the whole strategy. Combining those concepts would make the flexible “scan any tag unless I choose stricter unlocks” behavior harder to understand.
- **Physical Unlocks stays after the blocked-content setup.** Keeping it optional and later in the form avoids implying that a tag or code is required before someone can create a useful profile.
- **Profiles is not renamed to Modes or Routines.** `Profile` is already used consistently across the app, widgets, intents, deep links, and documentation. A broad terminology change needs a clearer benefit than we found here.
- **Breaks do not extend to six hours.** A six-hour break stops being a break in practical terms. One hour gives substantially more room than the previous choices while keeping the control aligned with its purpose.
- **No Timer + Temporary Access strategy was added.** That proposal overlaps with timed breaks, pause timers, and Temporary Access, but its exact session behavior is still unclear. Adding another NFC/QR strategy pair before that behavior is settled would expand an already large strategy matrix.
- **Start menus were not removed.** Some users want to choose a duration each time, while others want a rigid default. `Ask Me Every Time` supports both without changing the existing default.
- **Locked Mode is out of scope for the core app.** The Family Foqos fork is a better place for parental controls and edit-locking workflows.
- **Temporary Access resets remain whole-hour intervals.** The new 1–24 hour range addresses the six-hour floor from item 7, but does not add a 30-minute recurring Pomodoro loop. That use case would need a separate minute-based design rather than another fixed reset choice.

## Verification

- Ran Swift formatting checks on the touched files.
- Ran `git diff --check`.
- Built and launched the `foqos` scheme on an iPhone 17 simulator running iOS 26.4.
- Confirmed that a saved timer value appears consistently in both the start flow and `Update Start Settings`.

Related to #466.
