### PR TITLE
Add reset escape for stuck countdown sessions

### DIFF
--- a/Foqos/Utils/SessionTimeCalculator.swift
+++ b/Foqos/Utils/SessionTimeCalculator.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 enum SessionTimeCalculator {
-  static let countdownResetGracePeriod: TimeInterval = 60
+  static let countdownReloadDelay: TimeInterval = 30
+  static let countdownResetGracePeriod: TimeInterval = 90
 
   private static let timerStrategyIds: Set<String> = [
     NFCTimerBlockingStrategy.id,
@@ -39,6 +40,10 @@ enum SessionTimeCalculator {
     }
 
     return expectedEndTime.addingTimeInterval(countdownResetGracePeriod) <= date
+  }
+
+  static func countdownReloadTime(for session: BlockedProfileSession) -> Date? {
+    expectedEndTime(for: session)?.addingTimeInterval(countdownReloadDelay)
   }
 
   static func expectedEndTime(for session: BlockedProfileSession) -> Date? {

--- a/Foqos/Utils/SessionTimeCalculator.swift
+++ b/Foqos/Utils/SessionTimeCalculator.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum SessionTimeCalculator {
+  static let countdownResetGracePeriod: TimeInterval = 60
+
   private static let timerStrategyIds: Set<String> = [
     NFCTimerBlockingStrategy.id,
     QRTimerBlockingStrategy.id,
@@ -26,6 +28,17 @@ enum SessionTimeCalculator {
     }
 
     return elapsedFocusTime ?? self.elapsedFocusTime(for: session, at: date)
+  }
+
+  static func isCountdownExpired(
+    for session: BlockedProfileSession,
+    at date: Date = Date()
+  ) -> Bool {
+    guard let expectedEndTime = expectedEndTime(for: session) else {
+      return false
+    }
+
+    return expectedEndTime.addingTimeInterval(countdownResetGracePeriod) <= date
   }
 
   static func expectedEndTime(for session: BlockedProfileSession) -> Date? {

--- a/Foqos/Utils/SessionTimeCalculator.swift
+++ b/Foqos/Utils/SessionTimeCalculator.swift
@@ -42,8 +42,15 @@ enum SessionTimeCalculator {
     return expectedEndTime.addingTimeInterval(countdownResetGracePeriod) <= date
   }
 
-  static func countdownReloadTime(for session: BlockedProfileSession) -> Date? {
-    expectedEndTime(for: session)?.addingTimeInterval(countdownReloadDelay)
+  static func isCountdownReloadDue(
+    for session: BlockedProfileSession,
+    at date: Date = Date()
+  ) -> Bool {
+    guard let expectedEndTime = expectedEndTime(for: session) else {
+      return false
+    }
+
+    return expectedEndTime.addingTimeInterval(countdownReloadDelay) <= date
   }
 
   static func expectedEndTime(for session: BlockedProfileSession) -> Date? {

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -60,6 +60,14 @@ class StrategyManager: ObservableObject {
     return activeSession?.isPauseActive == true
   }
 
+  var isCountdownExpired: Bool {
+    guard let activeSession else {
+      return false
+    }
+
+    return SessionTimeCalculator.isCountdownExpired(for: activeSession)
+  }
+
   func defaultReminderMessage(forProfile profile: BlockedProfiles?) -> String {
     let baseMessage = "Get back to productivity"
     guard let profile else {
@@ -112,6 +120,37 @@ class StrategyManager: ObservableObject {
     } else {
       startBreak(context: context)
     }
+  }
+
+  func resetExpiredCountdown(context: ModelContext) {
+    guard let expiredSession = activeSession,
+      SessionTimeCalculator.isCountdownExpired(for: expiredSession)
+    else {
+      errorMessage = "The session can only be reset after its timer reaches zero."
+      return
+    }
+
+    let profile = expiredSession.blockedProfile
+    let descriptor = FetchDescriptor<BlockedProfileSession>(
+      predicate: #Predicate { $0.endTime == nil }
+    )
+    let unfinishedSessions = (try? context.fetch(descriptor)) ?? [expiredSession]
+
+    for session in unfinishedSessions where session.isActive {
+      session.endSession()
+    }
+
+    do {
+      try context.save()
+    } catch {
+      errorMessage = "The session was reset, but its history could not be saved."
+    }
+
+    SharedData.flushActiveSession()
+    appBlocker.deactivateRestrictions()
+    SoftUnblockGrantScheduler.stopAll()
+    SoftUnblockGrantStore.clearAll()
+    handleSessionEnded(profile: profile, shouldScheduleReminder: false)
   }
 
   func startTimer() {
@@ -586,7 +625,10 @@ class StrategyManager: ObservableObject {
     WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
   }
 
-  private func handleSessionEnded(profile: BlockedProfiles) {
+  private func handleSessionEnded(
+    profile: BlockedProfiles,
+    shouldScheduleReminder: Bool = true
+  ) {
     self.dismissView()
 
     // Remove any timers and notifications that were scheduled
@@ -594,7 +636,9 @@ class StrategyManager: ObservableObject {
     self.activeSession = nil
     ActiveProfileSyncStore.publish(session: nil)
     self.liveActivityManager.endSessionActivity()
-    self.scheduleReminder(profile: profile)
+    if shouldScheduleReminder {
+      self.scheduleReminder(profile: profile)
+    }
 
     self.stopTimer()
     self.elapsedTime = 0

--- a/Foqos/Views/ActiveProfileSessionView.swift
+++ b/Foqos/Views/ActiveProfileSessionView.swift
@@ -14,8 +14,10 @@ struct ActiveProfileSessionView: View {
   let isBreakAvailable: Bool
   let isBreakActive: Bool
   let isPauseActive: Bool
+  let isCountdownExpired: Bool
   let onBreakTapped: () -> Void
   let onStopTapped: () -> Void
+  let onExpiredCountdownReset: () -> Void
 
   @State private var showEmergencyView = false
   @State private var showProfileInsights = false
@@ -251,37 +253,54 @@ struct ActiveProfileSessionView: View {
 
   private var actionSection: some View {
     VStack(spacing: 12) {
-      if !isPauseActive && isBreakAvailable {
-        ActiveSessionActionButton(
-          title: breakButtonTitle,
-          iconName: "cup.and.heat.waves.fill",
-          imageName: "CoffeeStickerIcon",
-          role: isBreakActive ? .warning : .standard,
-          requiresLongPress: true,
-          action: onBreakTapped
-        )
-      }
+      if isCountdownExpired {
+        VStack(spacing: 8) {
+          Text("This timer finished, but the session is still active.")
+            .font(.footnote)
+            .fontWeight(.semibold)
+            .foregroundStyle(supportingTextColor)
+            .multilineTextAlignment(.center)
 
-      HStack(spacing: 12) {
-        if profile.enableEmergencyUnblock {
           ActiveSessionActionButton(
-            title: "Emergency",
-            iconName: "exclamationmark.triangle.fill",
+            title: "Reset Session",
+            iconName: "arrow.counterclockwise",
             role: .destructive,
-            action: {
-              showEmergencyView = true
-            }
+            action: onExpiredCountdownReset
+          )
+        }
+      } else {
+        if !isPauseActive && isBreakAvailable {
+          ActiveSessionActionButton(
+            title: breakButtonTitle,
+            iconName: "cup.and.heat.waves.fill",
+            imageName: "CoffeeStickerIcon",
+            role: isBreakActive ? .warning : .standard,
+            requiresLongPress: true,
+            action: onBreakTapped
           )
         }
 
-        if showStopButton {
-          ActiveSessionActionButton(
-            title: stopButtonAction.title,
-            iconName: stopButtonAction.systemImageName,
-            imageName: stopButtonAction.assetImageName,
-            role: .standard,
-            action: onStopTapped
-          )
+        HStack(spacing: 12) {
+          if profile.enableEmergencyUnblock {
+            ActiveSessionActionButton(
+              title: "Emergency",
+              iconName: "exclamationmark.triangle.fill",
+              role: .destructive,
+              action: {
+                showEmergencyView = true
+              }
+            )
+          }
+
+          if showStopButton {
+            ActiveSessionActionButton(
+              title: stopButtonAction.title,
+              iconName: stopButtonAction.systemImageName,
+              imageName: stopButtonAction.assetImageName,
+              role: .standard,
+              action: onStopTapped
+            )
+          }
         }
       }
     }
@@ -669,8 +688,10 @@ private struct ActiveSessionPressStyle: ButtonStyle {
     isBreakAvailable: true,
     isBreakActive: false,
     isPauseActive: false,
+    isCountdownExpired: false,
     onBreakTapped: {},
-    onStopTapped: {}
+    onStopTapped: {},
+    onExpiredCountdownReset: {}
   )
   .environmentObject(StrategyManager())
   .environmentObject(ThemeManager.shared)

--- a/Foqos/Views/ActiveProfileSessionView.swift
+++ b/Foqos/Views/ActiveProfileSessionView.swift
@@ -15,10 +15,8 @@ struct ActiveProfileSessionView: View {
   let isBreakActive: Bool
   let isPauseActive: Bool
   let isCountdownExpired: Bool
-  let countdownReloadTime: Date?
   let onBreakTapped: () -> Void
   let onStopTapped: () -> Void
-  let onCountdownReload: () -> Void
   let onExpiredCountdownReset: () -> Void
 
   @State private var showEmergencyView = false
@@ -111,9 +109,6 @@ struct ActiveProfileSessionView: View {
     }
     .onReceive(focusMessageTimer) { _ in
       rotateFocusMessage()
-    }
-    .task(id: countdownReloadTime) {
-      await reloadSessionAfterCountdown()
     }
     .onReceive(strategyManager.$errorMessage) { errorMessage in
       guard let message = errorMessage else { return }
@@ -316,18 +311,6 @@ struct ActiveProfileSessionView: View {
     withAnimation(.easeInOut(duration: 0.35)) {
       focusMessageIndex = (focusMessageIndex + 1) % FocusMessages.messages.count
     }
-  }
-
-  private func reloadSessionAfterCountdown() async {
-    guard let countdownReloadTime else { return }
-
-    let delay = countdownReloadTime.timeIntervalSinceNow
-    if delay > 0 {
-      try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-    }
-
-    guard !Task.isCancelled else { return }
-    onCountdownReload()
   }
 
   private func dismissAlert() {
@@ -706,10 +689,8 @@ private struct ActiveSessionPressStyle: ButtonStyle {
     isBreakActive: false,
     isPauseActive: false,
     isCountdownExpired: false,
-    countdownReloadTime: nil,
     onBreakTapped: {},
     onStopTapped: {},
-    onCountdownReload: {},
     onExpiredCountdownReset: {}
   )
   .environmentObject(StrategyManager())

--- a/Foqos/Views/ActiveProfileSessionView.swift
+++ b/Foqos/Views/ActiveProfileSessionView.swift
@@ -15,8 +15,10 @@ struct ActiveProfileSessionView: View {
   let isBreakActive: Bool
   let isPauseActive: Bool
   let isCountdownExpired: Bool
+  let countdownReloadTime: Date?
   let onBreakTapped: () -> Void
   let onStopTapped: () -> Void
+  let onCountdownReload: () -> Void
   let onExpiredCountdownReset: () -> Void
 
   @State private var showEmergencyView = false
@@ -109,6 +111,9 @@ struct ActiveProfileSessionView: View {
     }
     .onReceive(focusMessageTimer) { _ in
       rotateFocusMessage()
+    }
+    .task(id: countdownReloadTime) {
+      await reloadSessionAfterCountdown()
     }
     .onReceive(strategyManager.$errorMessage) { errorMessage in
       guard let message = errorMessage else { return }
@@ -311,6 +316,18 @@ struct ActiveProfileSessionView: View {
     withAnimation(.easeInOut(duration: 0.35)) {
       focusMessageIndex = (focusMessageIndex + 1) % FocusMessages.messages.count
     }
+  }
+
+  private func reloadSessionAfterCountdown() async {
+    guard let countdownReloadTime else { return }
+
+    let delay = countdownReloadTime.timeIntervalSinceNow
+    if delay > 0 {
+      try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+    }
+
+    guard !Task.isCancelled else { return }
+    onCountdownReload()
   }
 
   private func dismissAlert() {
@@ -689,8 +706,10 @@ private struct ActiveSessionPressStyle: ButtonStyle {
     isBreakActive: false,
     isPauseActive: false,
     isCountdownExpired: false,
+    countdownReloadTime: nil,
     onBreakTapped: {},
     onStopTapped: {},
+    onCountdownReload: {},
     onExpiredCountdownReset: {}
   )
   .environmentObject(StrategyManager())

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -275,11 +275,17 @@ struct HomeView: View {
           isBreakActive: isBreakActive,
           isPauseActive: isPauseActive,
           isCountdownExpired: strategyManager.isCountdownExpired,
+          countdownReloadTime: strategyManager.activeSession.flatMap {
+            SessionTimeCalculator.countdownReloadTime(for: $0)
+          },
           onBreakTapped: {
             strategyManager.toggleBreak(context: context)
           },
           onStopTapped: {
             strategyButtonPress(activeProfile)
+          },
+          onCountdownReload: {
+            strategyManager.loadActiveSession(context: context)
           },
           onExpiredCountdownReset: {
             strategyManager.resetExpiredCountdown(context: context)

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -85,6 +85,14 @@ struct HomeView: View {
     return strategyManager.isPauseActive
   }
 
+  private var isCountdownReloadDue: Bool {
+    guard let activeSession = strategyManager.activeSession else {
+      return false
+    }
+
+    return SessionTimeCalculator.isCountdownReloadDue(for: activeSession)
+  }
+
   private var canCreateProfiles: Bool {
     return !isBlocking
   }
@@ -238,6 +246,10 @@ struct HomeView: View {
         unloadApp()
       }
     }
+    .onChange(of: isCountdownReloadDue, initial: true) { _, shouldReload in
+      guard shouldReload else { return }
+      strategyManager.loadActiveSession(context: context)
+    }
     .onChange(of: isBlocking) { _, newValue in
       if !newValue {
         showActiveProfileSessionView = false
@@ -275,17 +287,11 @@ struct HomeView: View {
           isBreakActive: isBreakActive,
           isPauseActive: isPauseActive,
           isCountdownExpired: strategyManager.isCountdownExpired,
-          countdownReloadTime: strategyManager.activeSession.flatMap {
-            SessionTimeCalculator.countdownReloadTime(for: $0)
-          },
           onBreakTapped: {
             strategyManager.toggleBreak(context: context)
           },
           onStopTapped: {
             strategyButtonPress(activeProfile)
-          },
-          onCountdownReload: {
-            strategyManager.loadActiveSession(context: context)
           },
           onExpiredCountdownReset: {
             strategyManager.resetExpiredCountdown(context: context)

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -274,11 +274,15 @@ struct HomeView: View {
           isBreakAvailable: isBreakAvailable,
           isBreakActive: isBreakActive,
           isPauseActive: isPauseActive,
+          isCountdownExpired: strategyManager.isCountdownExpired,
           onBreakTapped: {
             strategyManager.toggleBreak(context: context)
           },
           onStopTapped: {
             strategyButtonPress(activeProfile)
+          },
+          onExpiredCountdownReset: {
+            strategyManager.resetExpiredCountdown(context: context)
           }
         )
       }

--- a/foqosTests/SessionTimeCalculatorTests.swift
+++ b/foqosTests/SessionTimeCalculatorTests.swift
@@ -40,13 +40,18 @@ final class SessionTimeCalculatorTests: XCTestCase {
     session.breakStartTime = startTime.addingTimeInterval(6 * 60 * 60)
 
     let breakEndTime = session.breakStartTime!.addingTimeInterval(30 * 60)
-    let reloadTime = breakEndTime.addingTimeInterval(
-      SessionTimeCalculator.countdownReloadDelay
-    )
 
-    XCTAssertEqual(
-      SessionTimeCalculator.countdownReloadTime(for: session),
-      reloadTime
+    XCTAssertFalse(
+      SessionTimeCalculator.isCountdownReloadDue(
+        for: session,
+        at: breakEndTime.addingTimeInterval(SessionTimeCalculator.countdownReloadDelay - 1)
+      )
+    )
+    XCTAssertTrue(
+      SessionTimeCalculator.isCountdownReloadDue(
+        for: session,
+        at: breakEndTime.addingTimeInterval(SessionTimeCalculator.countdownReloadDelay)
+      )
     )
 
     XCTAssertFalse(

--- a/foqosTests/SessionTimeCalculatorTests.swift
+++ b/foqosTests/SessionTimeCalculatorTests.swift
@@ -24,6 +24,64 @@ final class SessionTimeCalculatorTests: XCTestCase {
     XCTAssertEqual(displayTime, 45 * 60, accuracy: 0.1)
   }
 
+  func testExpiredBreakCountdownIsDetectedAfterGracePeriod() {
+    let startTime = Date(timeIntervalSinceReferenceDate: 1_000)
+    let profile = makeProfile(
+      strategyId: NFCTimerBlockingStrategy.id,
+      durationInMinutes: 18 * 60,
+      enableBreaks: true,
+      breakTimeInMinutes: 30
+    )
+    let session = BlockedProfileSession(
+      tag: NFCTimerBlockingStrategy.id,
+      blockedProfile: profile
+    )
+    session.startTime = startTime
+    session.breakStartTime = startTime.addingTimeInterval(6 * 60 * 60)
+
+    let breakEndTime = session.breakStartTime!.addingTimeInterval(30 * 60)
+
+    XCTAssertFalse(
+      SessionTimeCalculator.isCountdownExpired(
+        for: session,
+        at: breakEndTime
+      )
+    )
+    XCTAssertFalse(
+      SessionTimeCalculator.isCountdownExpired(
+        for: session,
+        at: breakEndTime.addingTimeInterval(
+          SessionTimeCalculator.countdownResetGracePeriod - 1
+        )
+      )
+    )
+    XCTAssertTrue(
+      SessionTimeCalculator.isCountdownExpired(
+        for: session,
+        at: breakEndTime.addingTimeInterval(
+          SessionTimeCalculator.countdownResetGracePeriod
+        )
+      )
+    )
+  }
+
+  func testManualSessionDoesNotHaveExpiredCountdown() {
+    let startTime = Date(timeIntervalSinceReferenceDate: 1_000)
+    let profile = makeProfile(strategyId: ManualBlockingStrategy.id)
+    let session = BlockedProfileSession(
+      tag: ManualBlockingStrategy.id,
+      blockedProfile: profile
+    )
+    session.startTime = startTime
+
+    XCTAssertFalse(
+      SessionTimeCalculator.isCountdownExpired(
+        for: session,
+        at: startTime.addingTimeInterval(24 * 60 * 60)
+      )
+    )
+  }
+
   func testManualSessionDisplaysElapsedTime() {
     let startTime = Date(timeIntervalSinceReferenceDate: 1_000)
     let profile = makeProfile(strategyId: ManualBlockingStrategy.id)

--- a/foqosTests/SessionTimeCalculatorTests.swift
+++ b/foqosTests/SessionTimeCalculatorTests.swift
@@ -40,6 +40,14 @@ final class SessionTimeCalculatorTests: XCTestCase {
     session.breakStartTime = startTime.addingTimeInterval(6 * 60 * 60)
 
     let breakEndTime = session.breakStartTime!.addingTimeInterval(30 * 60)
+    let reloadTime = breakEndTime.addingTimeInterval(
+      SessionTimeCalculator.countdownReloadDelay
+    )
+
+    XCTAssertEqual(
+      SessionTimeCalculator.countdownReloadTime(for: session),
+      reloadTime
+    )
 
     XCTAssertFalse(
       SessionTimeCalculator.isCountdownExpired(


### PR DESCRIPTION
## Summary
- detect countdown sessions that remain active for 60 seconds after reaching zero
- replace normal break, emergency, and stop actions with a Reset Session escape state
- end unfinished sessions and clear restrictions, timer activities, shared state, and temporary grants
- avoid scheduling a new reminder when recovering an expired session

## Testing
- `make test`
- manually verified the expired-break recovery flow on an iPhone 17 simulator running iOS 26.4

Closes #475