### PR TITLE
fix: Total Break Time for sessions with multiple breaks

### DIFF
--- a/Foqos/Components/Sessions/SessionDetailsView.swift
+++ b/Foqos/Components/Sessions/SessionDetailsView.swift
@@ -12,7 +12,7 @@ struct SessionDetailsView: View {
         SessionInfoSection(session: session)
         TimingSection(session: session)
 
-        if session.breakStartTime != nil && session.breakEndTime != nil {
+        if session.totalBreakDuration > 0 {
           BreakSection(session: session)
         }
 

--- a/Foqos/Components/Sessions/SessionDetailsView.swift
+++ b/Foqos/Components/Sessions/SessionDetailsView.swift
@@ -82,15 +82,6 @@ private struct TimingSection: View {
 private struct BreakSection: View {
   let session: BlockedProfileSession
 
-  var breakDuration: TimeInterval? {
-    guard let breakStartTime = session.breakStartTime,
-      let breakEndTime = session.breakEndTime
-    else {
-      return nil
-    }
-    return breakEndTime.timeIntervalSince(breakStartTime)
-  }
-
   var body: some View {
     Section("Break") {
       if let breakStartTime = session.breakStartTime {
@@ -107,10 +98,10 @@ private struct BreakSection: View {
         )
       }
 
-      if let breakDuration = breakDuration {
+      if session.totalBreakDuration > 0 {
         InfoRow(
-          label: "Duration",
-          value: "\(Int(breakDuration / 60))m"
+          label: "Total Duration",
+          value: "\(Int(session.totalBreakDuration / 60))m"
         )
       }
     }

--- a/Foqos/Components/Sessions/SessionRow.swift
+++ b/Foqos/Components/Sessions/SessionRow.swift
@@ -22,11 +22,11 @@ struct SessionRow: View {
           .foregroundStyle(.secondary)
       }
 
-      if let breakDuration = session.breakDuration, breakDuration > 0 {
+      if session.totalBreakDuration > 0 {
         HStack(spacing: 6) {
           Image(systemName: "cup.and.saucer")
             .font(.caption)
-          Text("\(Int(breakDuration / 60))m")
+          Text("\(Int(session.totalBreakDuration / 60))m")
             .monospacedDigit()
         }
         .font(.caption)
@@ -36,17 +36,5 @@ struct SessionRow: View {
     .padding(.vertical, 6)
     .frame(maxWidth: .infinity, alignment: .leading)
     .contentShape(Rectangle())
-  }
-}
-
-extension BlockedProfileSession {
-  var breakDuration: TimeInterval? {
-    guard let breakStartTime = breakStartTime,
-      let breakEndTime = breakEndTime
-    else {
-      return nil
-    }
-
-    return breakEndTime.timeIntervalSince(breakStartTime)
   }
 }

--- a/Foqos/Models/BlockedProfileSessions.swift
+++ b/Foqos/Models/BlockedProfileSessions.swift
@@ -63,15 +63,27 @@ class BlockedProfileSession {
   /// `breakStartTime` and `breakEndTime` only ever describe the most recent break, because
   /// `startBreak(at:)` clears them whenever multiple breaks are allowed, so reporting has to
   /// read the accumulator and fall back to the timestamps for single-break sessions where it
-  /// stays zero. Deliberately independent of the profile's current `allowMultipleBreaks`
-  /// value, so toggling that setting cannot rewrite sessions that are already recorded.
+  /// stays zero. If a session ends during a break, its end time closes that final partial break
+  /// because the accumulator is only updated by `endBreak(at:)`. Deliberately independent of
+  /// the profile's current `allowMultipleBreaks` value, so toggling that setting cannot rewrite
+  /// sessions that are already recorded.
   var totalBreakDuration: TimeInterval {
-    var lastBreakDuration: TimeInterval = 0
-    if let breakStartTime, let breakEndTime {
-      lastBreakDuration = max(0, breakEndTime.timeIntervalSince(breakStartTime))
+    let accumulatedDuration = max(0, usedBreakDurationInSeconds)
+    guard let breakStartTime else {
+      return accumulatedDuration
     }
 
-    return max(usedBreakDurationInSeconds, lastBreakDuration)
+    if let breakEndTime {
+      let lastBreakDuration = max(0, breakEndTime.timeIntervalSince(breakStartTime))
+      return max(accumulatedDuration, lastBreakDuration)
+    }
+
+    guard let endTime else {
+      return accumulatedDuration
+    }
+
+    let finalPartialBreakDuration = max(0, endTime.timeIntervalSince(breakStartTime))
+    return accumulatedDuration + finalPartialBreakDuration
   }
 
   init(

--- a/Foqos/Models/BlockedProfileSessions.swift
+++ b/Foqos/Models/BlockedProfileSessions.swift
@@ -58,6 +58,22 @@ class BlockedProfileSession {
     TimeInterval(blockedProfile.breakTimeInMinutes * 60)
   }
 
+  /// Break time this session consumed, across every break it contained.
+  ///
+  /// `breakStartTime` and `breakEndTime` only ever describe the most recent break, because
+  /// `startBreak(at:)` clears them whenever multiple breaks are allowed, so reporting has to
+  /// read the accumulator and fall back to the timestamps for single-break sessions where it
+  /// stays zero. Deliberately independent of the profile's current `allowMultipleBreaks`
+  /// value, so toggling that setting cannot rewrite sessions that are already recorded.
+  var totalBreakDuration: TimeInterval {
+    var lastBreakDuration: TimeInterval = 0
+    if let breakStartTime, let breakEndTime {
+      lastBreakDuration = max(0, breakEndTime.timeIntervalSince(breakStartTime))
+    }
+
+    return max(usedBreakDurationInSeconds, lastBreakDuration)
+  }
+
   init(
     tag: String,
     blockedProfile: BlockedProfiles,

--- a/Foqos/Utils/ProfileInsightsUtil.swift
+++ b/Foqos/Utils/ProfileInsightsUtil.swift
@@ -104,15 +104,13 @@ class ProfileInsightsUtil: ObservableObject {
       return end.timeIntervalSince(session.startTime)
     }
 
-    // Breaks: assuming one optional break per session in current model
-    let sessionsWithBreaksArray = completed.filter { $0.breakStartTime != nil }
+    // A session can hold several breaks once multiple breaks are allowed, and only the last
+    // one survives on breakStartTime/breakEndTime, so totals come from totalBreakDuration.
+    let sessionsWithBreaksArray = completed.filter { $0.totalBreakDuration > 0 }
     let sessionsWithBreaks = sessionsWithBreaksArray.count
     let sessionsWithoutBreaks = completed.count - sessionsWithBreaks
 
-    let breakDurations: [TimeInterval] = sessionsWithBreaksArray.compactMap { session in
-      guard let start = session.breakStartTime, let end = session.breakEndTime else { return nil }
-      return end.timeIntervalSince(start)
-    }
+    let breakDurations: [TimeInterval] = sessionsWithBreaksArray.map { $0.totalBreakDuration }
 
     let total = durations.reduce(0, +)
     let count = durations.count
@@ -327,13 +325,8 @@ class ProfileInsightsUtil: ObservableObject {
       guard let breakStart = session.breakStartTime else { continue }
       let day = calendar.startOfDay(for: breakStart)
 
-      var breakDuration: TimeInterval = 0
-      if let breakEnd = session.breakEndTime {
-        breakDuration = breakEnd.timeIntervalSince(breakStart)
-      }
-
       let prior = buckets[day] ?? (0, 0)
-      buckets[day] = (prior.count + 1, prior.totalDuration + breakDuration)
+      buckets[day] = (prior.count + 1, prior.totalDuration + session.totalBreakDuration)
     }
 
     var results: [BreakDayAggregate] = []
@@ -379,13 +372,8 @@ class ProfileInsightsUtil: ObservableObject {
       guard let breakStart = session.breakStartTime else { continue }
       let hour = calendar.component(.hour, from: breakStart)
 
-      var breakDuration: TimeInterval = 0
-      if let breakEnd = session.breakEndTime {
-        breakDuration = breakEnd.timeIntervalSince(breakStart)
-      }
-
       countsByHour[hour, default: 0] += 1
-      totalsByHour[hour, default: 0] += breakDuration
+      totalsByHour[hour, default: 0] += session.totalBreakDuration
     }
 
     var results: [BreakHourAggregate] = []

--- a/foqosTests/ProfileInsightsUtilTests.swift
+++ b/foqosTests/ProfileInsightsUtilTests.swift
@@ -1,0 +1,215 @@
+import SwiftData
+import XCTest
+
+@testable import foqos
+
+@MainActor
+final class ProfileInsightsUtilTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    SharedData.flushActiveSession()
+  }
+
+  override func tearDown() {
+    SharedData.flushActiveSession()
+    super.tearDown()
+  }
+
+  func testMultipleBreaksOnlyLeaveTheLastBreakOnTheTimestamps() throws {
+    let context = try makeContext()
+    let profile = makeProfile(in: context, allowMultipleBreaks: true, breakTimeInMinutes: 30)
+    let start = Date(timeIntervalSinceReferenceDate: 1_000)
+    let session = makeSession(
+      for: profile,
+      in: context,
+      startingAt: start,
+      breaks: [(60, 10), (120, 10), (180, 5)],
+      endingAfter: 240
+    )
+    try context.save()
+
+    XCTAssertEqual(session.breakStartTime, start.addingTimeInterval(180 * 60))
+    XCTAssertEqual(session.breakEndTime, start.addingTimeInterval(185 * 60))
+    XCTAssertEqual(session.usedBreakDurationInSeconds, 25 * 60, accuracy: 0.1)
+    XCTAssertEqual(session.totalBreakDuration, 25 * 60, accuracy: 0.1)
+  }
+
+  func testTotalBreakTimeCountsEveryBreakInASession() throws {
+    let context = try makeContext()
+    let profile = makeProfile(in: context, allowMultipleBreaks: true, breakTimeInMinutes: 30)
+    let start = Date(timeIntervalSinceReferenceDate: 1_000)
+    _ = makeSession(
+      for: profile,
+      in: context,
+      startingAt: start,
+      breaks: [(60, 10), (120, 10), (180, 5)],
+      endingAfter: 240
+    )
+    try context.save()
+
+    let metrics = ProfileInsightsUtil(profile: profile).metrics
+
+    XCTAssertEqual(metrics.totalBreakTime, 25 * 60, accuracy: 0.1)
+    XCTAssertEqual(metrics.averageBreakDuration ?? 0, 25 * 60, accuracy: 0.1)
+    XCTAssertEqual(metrics.sessionsWithBreaks, 1)
+    XCTAssertEqual(metrics.sessionsWithoutBreaks, 0)
+  }
+
+  func testTotalBreakTimeIsCappedByTheConfiguredAllowance() throws {
+    let context = try makeContext()
+    let profile = makeProfile(in: context, allowMultipleBreaks: true, breakTimeInMinutes: 30)
+    let start = Date(timeIntervalSinceReferenceDate: 1_000)
+    _ = makeSession(
+      for: profile,
+      in: context,
+      startingAt: start,
+      breaks: [(60, 25), (120, 25)],
+      endingAfter: 240
+    )
+    try context.save()
+
+    let metrics = ProfileInsightsUtil(profile: profile).metrics
+
+    XCTAssertEqual(metrics.totalBreakTime, 30 * 60, accuracy: 0.1)
+  }
+
+  func testSingleBreakSessionStillReportsItsBreak() throws {
+    let context = try makeContext()
+    let profile = makeProfile(in: context, allowMultipleBreaks: false, breakTimeInMinutes: 15)
+    let start = Date(timeIntervalSinceReferenceDate: 1_000)
+    let session = makeSession(
+      for: profile,
+      in: context,
+      startingAt: start,
+      breaks: [(30, 12)],
+      endingAfter: 120
+    )
+    try context.save()
+
+    // The accumulator is only maintained for reusable breaks, so single-break sessions have
+    // to keep falling back to the timestamp pair.
+    XCTAssertEqual(session.usedBreakDurationInSeconds, 0, accuracy: 0.1)
+    XCTAssertEqual(session.totalBreakDuration, 12 * 60, accuracy: 0.1)
+
+    let metrics = ProfileInsightsUtil(profile: profile).metrics
+
+    XCTAssertEqual(metrics.totalBreakTime, 12 * 60, accuracy: 0.1)
+    XCTAssertEqual(metrics.sessionsWithBreaks, 1)
+  }
+
+  func testTotalBreakTimeIsUnaffectedByLaterSettingChanges() throws {
+    let context = try makeContext()
+    let profile = makeProfile(in: context, allowMultipleBreaks: true, breakTimeInMinutes: 30)
+    let start = Date(timeIntervalSinceReferenceDate: 1_000)
+    let session = makeSession(
+      for: profile,
+      in: context,
+      startingAt: start,
+      breaks: [(60, 10), (120, 10)],
+      endingAfter: 240
+    )
+    try context.save()
+
+    profile.allowMultipleBreaks = false
+    try context.save()
+
+    XCTAssertEqual(session.totalBreakDuration, 20 * 60, accuracy: 0.1)
+    XCTAssertEqual(
+      ProfileInsightsUtil(profile: profile).metrics.totalBreakTime,
+      20 * 60,
+      accuracy: 0.1
+    )
+  }
+
+  func testSessionWithoutBreaksReportsNoBreakTime() throws {
+    let context = try makeContext()
+    let profile = makeProfile(in: context, allowMultipleBreaks: true, breakTimeInMinutes: 30)
+    let start = Date(timeIntervalSinceReferenceDate: 1_000)
+    _ = makeSession(for: profile, in: context, startingAt: start, breaks: [], endingAfter: 120)
+    try context.save()
+
+    let metrics = ProfileInsightsUtil(profile: profile).metrics
+
+    XCTAssertEqual(metrics.totalBreakTime, 0, accuracy: 0.1)
+    XCTAssertNil(metrics.averageBreakDuration)
+    XCTAssertEqual(metrics.sessionsWithBreaks, 0)
+    XCTAssertEqual(metrics.sessionsWithoutBreaks, 1)
+  }
+
+  func testBreakDailyAggregateSumsEveryBreakInTheDay() throws {
+    let context = try makeContext()
+    let profile = makeProfile(in: context, allowMultipleBreaks: true, breakTimeInMinutes: 30)
+    let calendar = Calendar.current
+    let day = calendar.startOfDay(for: Date(timeIntervalSinceReferenceDate: 400 * 24 * 60 * 60))
+    let start = day.addingTimeInterval(8 * 60 * 60)
+    _ = makeSession(
+      for: profile,
+      in: context,
+      startingAt: start,
+      breaks: [(60, 10), (120, 10), (180, 5)],
+      endingAfter: 240
+    )
+    try context.save()
+
+    let aggregates = ProfileInsightsUtil(profile: profile).breakDailyAggregates(endingOn: day)
+    let today = aggregates.first { calendar.isDate($0.date, inSameDayAs: day) }
+
+    XCTAssertEqual(today?.totalBreakDuration ?? 0, 25 * 60, accuracy: 0.1)
+  }
+
+  // MARK: - Helpers
+
+  private func makeContext() throws -> ModelContext {
+    let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+      for: BlockedProfileSession.self,
+      BlockedProfiles.self,
+      configurations: configuration
+    )
+    return ModelContext(container)
+  }
+
+  private func makeProfile(
+    in context: ModelContext,
+    allowMultipleBreaks: Bool,
+    breakTimeInMinutes: Int
+  ) -> BlockedProfiles {
+    let profile = BlockedProfiles(
+      name: "Focus",
+      blockingStrategyId: ManualBlockingStrategy.id,
+      enableBreaks: true,
+      breakTimeInMinutes: breakTimeInMinutes,
+      allowMultipleBreaks: allowMultipleBreaks
+    )
+    context.insert(profile)
+    return profile
+  }
+
+  /// Builds a completed session by driving the real break API, so the timestamps end up in the
+  /// same state the app leaves them in. Break offsets and durations are in minutes from the
+  /// session start.
+  private func makeSession(
+    for profile: BlockedProfiles,
+    in context: ModelContext,
+    startingAt start: Date,
+    breaks: [(offset: Int, duration: Int)],
+    endingAfter minutes: Int
+  ) -> BlockedProfileSession {
+    let session = BlockedProfileSession(
+      tag: ManualBlockingStrategy.id,
+      blockedProfile: profile
+    )
+    session.startTime = start
+    context.insert(session)
+
+    for entry in breaks {
+      session.startBreak(at: start.addingTimeInterval(TimeInterval(entry.offset * 60)))
+      session.endBreak(
+        at: start.addingTimeInterval(TimeInterval((entry.offset + entry.duration) * 60))
+      )
+    }
+
+    session.endTime = start.addingTimeInterval(TimeInterval(minutes * 60))
+    return session
+  }
+}

--- a/foqosTests/ProfileInsightsUtilTests.swift
+++ b/foqosTests/ProfileInsightsUtilTests.swift
@@ -55,6 +55,31 @@ final class ProfileInsightsUtilTests: XCTestCase {
     XCTAssertEqual(metrics.sessionsWithoutBreaks, 0)
   }
 
+  func testEndingSessionDuringBreakCountsFinalPartialBreak() throws {
+    let context = try makeContext()
+    let profile = makeProfile(in: context, allowMultipleBreaks: true, breakTimeInMinutes: 30)
+    let start = Date(timeIntervalSinceReferenceDate: 1_000)
+    let session = makeSession(
+      for: profile,
+      in: context,
+      startingAt: start,
+      breaks: [(60, 10), (120, 10)],
+      endingAfter: 240
+    )
+    session.endTime = nil
+    session.startBreak(at: start.addingTimeInterval(180 * 60))
+    session.endTime = start.addingTimeInterval(185 * 60)
+    try context.save()
+
+    XCTAssertEqual(session.usedBreakDurationInSeconds, 20 * 60, accuracy: 0.1)
+    XCTAssertEqual(session.totalBreakDuration, 25 * 60, accuracy: 0.1)
+
+    let metrics = ProfileInsightsUtil(profile: profile).metrics
+
+    XCTAssertEqual(metrics.totalBreakTime, 25 * 60, accuracy: 0.1)
+    XCTAssertEqual(metrics.sessionsWithBreaks, 1)
+  }
+
   func testTotalBreakTimeIsCappedByTheConfiguredAllowance() throws {
     let context = try makeContext()
     let profile = makeProfile(in: context, allowMultipleBreaks: true, breakTimeInMinutes: 30)


### PR DESCRIPTION
## AI Disclaimer
Solution coded with Claude Opus 5, while the bug was discovered by me from personal usage of the app. I have done my best to validate and think through the issue and solution, however I am a DevOps/BE engineer with little mobile app expertise.

## Summary

- Add `BlockedProfileSession.totalBreakDuration` as the single source of truth for
  how much break time a session consumed.
- Read it from Profile Insights (`totalBreakTime`, `averageBreakDuration`, the
  daily and hourly break aggregates) and from the session row and detail sheet.
- Add `ProfileInsightsUtilTests`, which had no coverage before.

Fixes #485

## Why

`startBreak(at:)` clears `breakStartTime` and `breakEndTime` on every new break when
`allowMultipleBreaks` is on, so the pair only ever describes the most recent break.
The running total lives in `usedBreakDurationInSeconds`, which `endBreak(at:)`
maintains and which `SessionTimeCalculator` and `LiveActivityManager` already read -
but the reporting paths still derived their numbers from the timestamps, so a session
with several breaks reported only the last one.

`totalBreakDuration` returns `max(usedBreakDurationInSeconds, lastBreakFromTimestamps)`.
That gives the accumulated total for reusable breaks, and falls back to the timestamp
pair for single-break profiles, where the accumulator is never written and stays zero.
It deliberately doesn't read `allowMultipleBreaks`, so turning the setting on or off
later can't retroactively change sessions that are already recorded.

## Notes for review

Two deliberate choices worth a look:

- `computeMetrics` now selects sessions with `totalBreakDuration > 0` rather than
  `breakStartTime != nil`. That makes the count, the total and the average describe
  the same set of sessions; previously the count included sessions whose break had no
  end time while the average excluded them. A session that ended mid-break is no
  longer counted under "with breaks", since it contributes no measured break time.
- The session detail sheet's break row is relabelled "Total Duration". Its Started
  and Ended rows are the most recent break, so without the label a multi-break session
  would show a total sitting under two timestamps that don't add up to it.

Not changed, because both need stored per-break data rather than a derived value:
`totalBreaksTaken` still counts sessions rather than breaks, and break aggregates
still bucket a session's break time by the last break's start time. The CSV export is
also untouched - its `break_start_time` and `break_end_time` columns are raw fields,
and adding a total would change the schema.

## Validation

- `make lint` - passes, no new warnings. The four touched files and the new test file
  are clean, and `swift-format format` leaves all of them unchanged. The repo's
  existing warnings, all in `FoqosWidget`, are unaffected (260 before and after).
- `make build` / `make test` - not run locally, no Xcode on this machine. The new
  tests are written against the existing `foqosTests` patterns (in-memory
  `ModelContainer`, `SharedData.flushActiveSession()` in setUp/tearDown) and land in
  the target's synchronized group, so CI picks them up without a project change.
