### PR TITLE
Ignore scroll gestures over activity charts

### DIFF
--- a/Foqos/Components/Insights/MonthlySessionChart.swift
+++ b/Foqos/Components/Insights/MonthlySessionChart.swift
@@ -5,9 +5,7 @@ struct MonthlySessionChart: View {
   @EnvironmentObject private var themeManager: ThemeManager
   @Binding var selectedDay: MonthlyDayAggregate?
   let onDateSelected: ((Date?) -> Void)?
-  @State private var dragDay: MonthlyDayAggregate?
-  @State private var previousDragDay: MonthlyDayAggregate?
-  @State private var isDragging = false
+  @State private var selectionFeedbackTrigger = 0
 
   private var monthlySummary: MonthlySummary {
     viewModel.monthlySummary
@@ -85,14 +83,12 @@ struct MonthlySessionChart: View {
     selectedDay = day
     if let selectedDay = day {
       onDateSelected?(selectedDay.date)
+      selectionFeedbackTrigger += 1
     }
   }
 
   private func clearSelection() {
     selectedDay = nil
-    dragDay = nil
-    previousDragDay = nil
-    isDragging = false
     onDateSelected?(nil)
   }
 
@@ -174,31 +170,6 @@ struct MonthlySessionChart: View {
     }
   }
 
-  private func handleDrag(at location: CGPoint, in geometry: GeometryProxy) {
-    guard isDragging else { return }
-
-    let cellWidth = geometry.size.width / 7
-    let cellHeight = cellWidth  // Square cells
-
-    let column = Int(location.x / cellWidth)
-    let row = Int(location.y / cellHeight)
-
-    guard column >= 0, column < 7, row >= 0, row < weeksInMonth.count else { return }
-
-    let week = weeksInMonth[row]
-    guard column < week.count else { return }
-
-    let day = week[column]
-    guard day.dayOfMonth != 0 else { return }
-
-    if dragDay?.date != day.date {
-      previousDragDay = dragDay
-      dragDay = day
-      selectedDay = day
-      onDateSelected?(day.date)
-    }
-  }
-
   var body: some View {
     VStack(alignment: .leading, spacing: 10) {
       // Header
@@ -254,7 +225,7 @@ struct MonthlySessionChart: View {
         .animation(.spring(response: 0.25, dampingFraction: 0.85), value: selectedDay)
       }
 
-      // Grid with drag support
+      // Grid
       GeometryReader { geometry in
         LazyVStack(spacing: 4) {
           ForEach(weeksInMonth.indices, id: \.self) { weekIndex in
@@ -267,18 +238,6 @@ struct MonthlySessionChart: View {
         }
         .frame(maxWidth: .infinity)
         .coordinateSpace(name: "grid")
-        .gesture(
-          DragGesture(minimumDistance: 0, coordinateSpace: .named("grid"))
-            .onChanged { value in
-              isDragging = true
-              handleDrag(at: value.location, in: geometry)
-            }
-            .onEnded { _ in
-              isDragging = false
-              dragDay = nil
-              previousDragDay = nil
-            }
-        )
       }
       .frame(
         height: CGFloat(weeksInMonth.count) * (UIScreen.main.bounds.width - 32) / 7
@@ -289,13 +248,10 @@ struct MonthlySessionChart: View {
       legendView()
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    .sensoryFeedback(.impact(flexibility: .soft, intensity: 0.7), trigger: dragDay) { old, new in
-      old == nil && new != nil
-    }
-    .sensoryFeedback(.selection, trigger: previousDragDay) { old, new in
-      guard let oldDay = old, let newDay = new else { return false }
-      return oldDay.date != newDay.date
-    }
+    .sensoryFeedback(
+      .impact(flexibility: .soft, intensity: 0.7),
+      trigger: selectionFeedbackTrigger
+    )
   }
 }
 

--- a/Foqos/Components/Insights/WeeklySessionChart.swift
+++ b/Foqos/Components/Insights/WeeklySessionChart.swift
@@ -6,8 +6,7 @@ struct WeeklySessionChart: View {
   @EnvironmentObject private var themeManager: ThemeManager
   @Binding var selectedDay: WeeklyDayAggregate?
   let onDateSelected: ((Date?) -> Void)?
-  @State private var dragLabel: String?
-  @State private var previousLabel: String?
+  @State private var selectionFeedbackTrigger = 0
 
   private var chartView: some View {
     Chart {
@@ -57,13 +56,12 @@ struct WeeklySessionChart: View {
     selectedDay = viewModel.weeklySummary.days.first { $0.displayLabel == label }
     if let day = selectedDay {
       onDateSelected?(day.date)
+      selectionFeedbackTrigger += 1
     }
   }
 
   private func clearSelection() {
     selectedDay = nil
-    dragLabel = nil
-    previousLabel = nil
     onDateSelected?(nil)
   }
 
@@ -124,29 +122,20 @@ struct WeeklySessionChart: View {
       }
 
       chartView
-        .chartXSelection(value: $dragLabel)
-        .onChange(of: dragLabel) { oldValue, newValue in
-          // Track previous for haptic feedback
-          if let old = oldValue, let new = newValue, old != new {
-            previousLabel = old
-          }
-
-          // Update selection in real-time during drag
-          if let label = newValue {
-            selectDay(label)
-          }
+        .chartGesture { proxy in
+          SpatialTapGesture()
+            .onEnded { value in
+              guard let label: String = proxy.value(atX: value.location.x) else { return }
+              selectDay(label)
+            }
         }
         .onChange(of: viewModel.selectedDate) { _, _ in
           clearSelection()
         }
-        .sensoryFeedback(.impact(flexibility: .soft, intensity: 0.7), trigger: dragLabel) {
-          old, new in
-          old == nil && new != nil
-        }
-        .sensoryFeedback(.selection, trigger: previousLabel) { old, new in
-          guard let oldLabel = old, let newLabel = new else { return false }
-          return oldLabel != newLabel
-        }
+        .sensoryFeedback(
+          .impact(flexibility: .soft, intensity: 0.7),
+          trigger: selectionFeedbackTrigger
+        )
         .frame(maxWidth: .infinity)
         .frame(height: 210)
     }


### PR DESCRIPTION
## Summary

- replace weekly drag-based chart selection with a tap-only `SpatialTapGesture`
- remove the monthly zero-distance drag recognizer so vertical swipes remain with the home screen scroll view
- preserve one haptic response per successful day tap

## Testing

- `make build`
- manually verified in iOS Simulator that scrolling across the weekly and monthly charts does not select a day
- verified that tapping chart days still updates the selection

Closes #490