### PR TITLE
Improve QR scanner and reminder time input

### DIFF
--- a/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
@@ -529,6 +529,7 @@ struct BlockedProfileSessionSafeguardsSection: View {
 struct BlockedProfileNotificationsFields: View {
   @EnvironmentObject private var strategyManager: StrategyManager
   @EnvironmentObject private var themeManager: ThemeManager
+  @FocusState private var isReminderTimeFocused: Bool
 
   @ObservedObject var draft: BlockedProfileDraft
   var profile: BlockedProfiles?
@@ -536,6 +537,11 @@ struct BlockedProfileNotificationsFields: View {
   var showsSeparators: Bool = false
 
   var body: some View {
+    notificationFields
+  }
+
+  @ViewBuilder
+  private var notificationFields: some View {
     CustomToggle(
       title: "Live Activity",
       description:
@@ -566,11 +572,25 @@ struct BlockedProfileNotificationsFields: View {
           format: .number
         )
         .keyboardType(.numberPad)
-        .multilineTextAlignment(.trailing)
-        .frame(width: 50)
+        .multilineTextAlignment(.center)
+        .frame(width: 58)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(Color.secondary.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .stroke(
+              isReminderTimeFocused
+                ? themeManager.themeColor : Color.secondary.opacity(0.4),
+              lineWidth: isReminderTimeFocused ? 2 : 1
+            )
+        }
+        .focused($isReminderTimeFocused)
         .disabled(disabled)
         .font(.subheadline)
-        .foregroundColor(.secondary)
+        .foregroundStyle(disabled ? Color.secondary : Color.primary)
+        .accessibilityLabel("Reminder time in minutes")
 
         Text("minutes")
           .font(.subheadline)

--- a/Foqos/Components/Strategy/QRCodeScanner.swift
+++ b/Foqos/Components/Strategy/QRCodeScanner.swift
@@ -1,6 +1,84 @@
+import AVFoundation
 import CodeScanner
 import SwiftUI
 import UIKit
+
+private final class QRScannerCamera: ObservableObject {
+  let device: AVCaptureDevice?
+  let zoomRange: ClosedRange<Double>
+  let zoomFactors: [Double]
+
+  @Published private(set) var zoomFactor: Double
+
+  var supportsZoom: Bool {
+    zoomFactors.count > 1
+  }
+
+  init() {
+    let device =
+      AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back)
+      ?? AVCaptureDevice.default(for: .video)
+    let minimumZoomFactor = Double(device?.minAvailableVideoZoomFactor ?? 1)
+    let deviceMaximumZoomFactor = Double(device?.maxAvailableVideoZoomFactor ?? 1)
+    let maximumZoomFactor = max(minimumZoomFactor, min(deviceMaximumZoomFactor, 5))
+    let zoomRange = minimumZoomFactor...maximumZoomFactor
+    let standardZoomFactors = [1.0, 2.0, 5.0]
+    let availableZoomFactors = standardZoomFactors.filter { zoomRange.contains($0) }
+    let initialZoomFactor = availableZoomFactors.first ?? minimumZoomFactor
+
+    self.device = device
+    self.zoomRange = zoomRange
+    self.zoomFactors =
+      availableZoomFactors.isEmpty ? [initialZoomFactor] : availableZoomFactors
+    self.zoomFactor = initialZoomFactor
+
+    _ = applyZoomFactor(initialZoomFactor)
+  }
+
+  func setZoomFactor(_ zoomFactor: Double) {
+    guard let device else { return }
+
+    let clampedZoomFactor = min(
+      max(zoomFactor, zoomRange.lowerBound),
+      zoomRange.upperBound
+    )
+
+    if applyZoomFactor(clampedZoomFactor) {
+      self.zoomFactor = clampedZoomFactor
+    }
+  }
+
+  func cycleZoomFactor() {
+    guard
+      let currentIndex = zoomFactors.firstIndex(where: {
+        abs($0 - zoomFactor) < 0.05
+      })
+    else {
+      setZoomFactor(zoomFactors[0])
+      return
+    }
+
+    let nextIndex = zoomFactors.index(after: currentIndex)
+    setZoomFactor(nextIndex == zoomFactors.endIndex ? zoomFactors[0] : zoomFactors[nextIndex])
+  }
+
+  func formattedZoomFactor(_ zoomFactor: Double) -> String {
+    String(format: "%.0fx", zoomFactor)
+  }
+
+  private func applyZoomFactor(_ zoomFactor: Double) -> Bool {
+    guard let device else { return false }
+
+    do {
+      try device.lockForConfiguration()
+      device.videoZoomFactor = CGFloat(zoomFactor)
+      device.unlockForConfiguration()
+      return true
+    } catch {
+      return false
+    }
+  }
+}
 
 struct LabeledCodeScannerView: View {
   let heading: String
@@ -8,6 +86,7 @@ struct LabeledCodeScannerView: View {
   let simulatedData: String?
   let onScanResult: (Result<ScanResult, ScanError>) -> Void
 
+  @StateObject private var camera = QRScannerCamera()
   @State private var isShowingScanner = true
   @State private var errorMessage: String? = nil
   @State private var scanError: ScanError? = nil
@@ -36,7 +115,7 @@ struct LabeledCodeScannerView: View {
         .padding(.bottom)
 
       if isShowingScanner {
-        ZStack(alignment: .bottomTrailing) {
+        ZStack(alignment: .bottom) {
           CodeScannerView(
             codeTypes: [
               .aztec,
@@ -56,23 +135,13 @@ struct LabeledCodeScannerView: View {
             showViewfinder: true,
             shouldVibrateOnSuccess: true,
             isTorchOn: isTorchOn,
+            videoCaptureDevice: camera.device,
             completion: handleScanResult
           )
           .frame(maxWidth: .infinity, maxHeight: .infinity)
           .cornerRadius(12)
 
-          // Flashlight toggle button
-          Button(action: {
-            isTorchOn.toggle()
-          }) {
-            Image(systemName: isTorchOn ? "flashlight.on.fill" : "flashlight.slash")
-              .font(.system(size: 24))
-              .foregroundColor(.white)
-              .padding(12)
-              .background(Color.black.opacity(0.6))
-              .clipShape(Circle())
-          }
-          .padding(16)
+          scannerControls
         }
         .padding(.vertical, 10)
       } else if let scanError = scanError {
@@ -129,6 +198,43 @@ struct LabeledCodeScannerView: View {
       scanError = nil
       isTorchOn = false
     }
+  }
+
+  private var scannerControls: some View {
+    HStack {
+      if camera.supportsZoom {
+        Button {
+          camera.cycleZoomFactor()
+        } label: {
+          Text(camera.formattedZoomFactor(camera.zoomFactor))
+            .font(.caption.bold().monospacedDigit())
+            .frame(width: 48, height: 48)
+            .background(Color.black.opacity(0.65))
+            .clipShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Camera zoom")
+        .accessibilityValue(camera.formattedZoomFactor(camera.zoomFactor))
+        .accessibilityHint("Cycles through the available zoom levels")
+      }
+
+      Spacer()
+
+      Button(action: {
+        isTorchOn.toggle()
+      }) {
+        Image(systemName: isTorchOn ? "flashlight.on.fill" : "flashlight.slash")
+          .font(.system(size: 22))
+          .frame(width: 48, height: 48)
+          .background(Color.black.opacity(0.65))
+          .clipShape(Circle())
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(isTorchOn ? "Turn flashlight off" : "Turn flashlight on")
+    }
+    .foregroundStyle(.white)
+    .frame(maxWidth: .infinity)
+    .padding(16)
   }
 
   private func handleScanResult(_ result: Result<ScanResult, ScanError>) {

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -135,6 +135,7 @@ struct BlockedProfileView: View {
         )
 
       }
+      .scrollDismissesKeyboard(.interactively)
       .navigationTitle(isEditing ? "Edit Profile" : "New Profile")
       .toolbar {
         ToolbarItem(placement: .topBarLeading) {

--- a/Foqos/Views/GuidedBlockedProfileCreationView.swift
+++ b/Foqos/Views/GuidedBlockedProfileCreationView.swift
@@ -177,6 +177,7 @@ struct GuidedBlockedProfileCreationView: View {
               .transition(stepTransition)
           }
         }
+        .scrollDismissesKeyboard(.interactively)
         .animation(stepAnimation, value: currentStep)
         .frame(maxWidth: .infinity)
         .background(Color(.systemGroupedBackground))


### PR DESCRIPTION
## Summary

- add a single circular QR camera zoom button that cycles through supported 1x, 2x, and 5x levels
- keep the flashlight as a separate circular control on the opposite side
- make the reminder minutes field easier to identify and focus
- dismiss the keyboard interactively when scrolling either profile form

## Testing

- make build
- swift-format lint on all changed Swift files

Related to #496.