### PR TITLE
Redesign the active session screen

### DIFF
--- a/Foqos/Views/ActiveProfileSessionView.swift
+++ b/Foqos/Views/ActiveProfileSessionView.swift
@@ -5,6 +5,7 @@ import UIKit
 struct ActiveProfileSessionView: View {
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var strategyManager: StrategyManager
+  @EnvironmentObject private var themeManager: ThemeManager
 
   let profile: BlockedProfiles
   let elapsedTime: TimeInterval
@@ -21,6 +22,11 @@ struct ActiveProfileSessionView: View {
   @State private var showingAlert = false
   @State private var alertMessage = ""
   @State private var focusMessageIndex = Self.initialFocusMessageIndex()
+  @State private var animationSettings = ActiveSessionAnimationSettings.defaultValue
+
+  #if DEBUG
+    @State private var showingAnimationTuning = false
+  #endif
 
   private let focusMessageTimer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
 
@@ -71,8 +77,7 @@ struct ActiveProfileSessionView: View {
 
       Spacer(minLength: 24)
 
-      timer
-        .frame(maxWidth: .infinity)
+      timerPresentation
 
       Spacer(minLength: 24)
 
@@ -128,6 +133,10 @@ struct ActiveProfileSessionView: View {
       }
 
       Spacer()
+
+      #if DEBUG
+        animationTuningControl
+      #endif
     }
   }
 
@@ -141,6 +150,44 @@ struct ActiveProfileSessionView: View {
     .foregroundStyle(.primary)
     .accessibilityLabel("Close")
   }
+
+  #if DEBUG
+    private var animationTuningControl: some View {
+      ZStack {
+        if #available(iOS 26.0, *) {
+          animationTuningButton
+            .buttonStyle(.glass)
+            .buttonBorderShape(.circle)
+        } else {
+          animationTuningButton
+            .background(.ultraThinMaterial, in: Circle())
+            .overlay {
+              Circle()
+                .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
+            }
+            .buttonStyle(ActiveSessionPressStyle())
+        }
+      }
+      .popover(isPresented: $showingAnimationTuning) {
+        ActiveSessionAnimationTuningView(
+          settings: $animationSettings,
+          tint: themeManager.themeColor
+        )
+        .presentationCompactAdaptation(.popover)
+      }
+    }
+
+    private var animationTuningButton: some View {
+      Button(action: { showingAnimationTuning = true }) {
+        Image(systemName: "slider.horizontal.3")
+          .font(.system(size: 16, weight: .semibold))
+          .frame(width: 40, height: 40)
+          .contentShape(Circle())
+      }
+      .foregroundStyle(.primary)
+      .accessibilityLabel("Animation controls")
+    }
+  #endif
 
   private var statusMessage: String? {
     if isPauseActive {
@@ -171,6 +218,22 @@ struct ActiveProfileSessionView: View {
       .animation(.default, value: displayTime)
       .accessibilityLabel("Session time")
       .accessibilityValue(DateFormatters.formatDurationClock(displayTime))
+  }
+
+  private var timerPresentation: some View {
+    ZStack {
+      ActiveSessionPetalAnimation(
+        color: themeManager.themeColor,
+        settings: animationSettings,
+        timerTick: Int(max(elapsedTime, 0).rounded(.down))
+      )
+      .frame(maxWidth: 360, maxHeight: 300)
+
+      timer
+        .padding(.horizontal, 16)
+    }
+    .frame(maxWidth: .infinity)
+    .frame(height: 300)
   }
 
   private var profileDetails: some View {
@@ -299,34 +362,330 @@ struct ActiveProfileSessionView: View {
   }
 }
 
+private struct ActiveSessionAnimationSettings: Equatable {
+  static let defaultValue = ActiveSessionAnimationSettings(
+    petalCount: 8,
+    visibility: 1.15,
+    petalWidth: 0.9,
+    petalLength: 1.08,
+    bloomScale: 1,
+    centerOpening: 44,
+    breathingDuration: 18
+  )
+
+  var petalCount: Double
+  var visibility: Double
+  var petalWidth: Double
+  var petalLength: Double
+  var bloomScale: Double
+  var centerOpening: Double
+  var breathingDuration: Double
+}
+
+#if DEBUG
+  private struct ActiveSessionAnimationTuningView: View {
+    @Binding var settings: ActiveSessionAnimationSettings
+
+    let tint: Color
+
+    var body: some View {
+      VStack(alignment: .leading, spacing: 16) {
+        HStack {
+          Text("Rose Petals")
+            .font(.headline)
+
+          Spacer()
+
+          Button("Reset") {
+            settings = .defaultValue
+          }
+          .font(.subheadline.weight(.semibold))
+        }
+
+        tuningSlider(
+          title: "Petals",
+          valueText: String(Int(settings.petalCount.rounded())),
+          value: $settings.petalCount,
+          range: 5...12,
+          step: 1
+        )
+
+        tuningSlider(
+          title: "Petal visibility",
+          valueText: String(format: "%.2f×", settings.visibility),
+          value: $settings.visibility,
+          range: 0.25...2.5,
+          step: 0.05
+        )
+
+        tuningSlider(
+          title: "Petal width",
+          valueText: String(format: "%.2f×", settings.petalWidth),
+          value: $settings.petalWidth,
+          range: 0.5...2,
+          step: 0.05
+        )
+
+        tuningSlider(
+          title: "Petal length",
+          valueText: String(format: "%.2f×", settings.petalLength),
+          value: $settings.petalLength,
+          range: 0.8...1.25,
+          step: 0.05
+        )
+
+        tuningSlider(
+          title: "Bloom size",
+          valueText: String(format: "%.2f×", settings.bloomScale),
+          value: $settings.bloomScale,
+          range: 0.75...1.15,
+          step: 0.05
+        )
+
+        tuningSlider(
+          title: "Center opening",
+          valueText: String(format: "%.0f pt", settings.centerOpening),
+          value: $settings.centerOpening,
+          range: 0...80,
+          step: 2
+        )
+
+        tuningSlider(
+          title: "Breathing cycle",
+          valueText: String(format: "%.0fs", settings.breathingDuration),
+          value: $settings.breathingDuration,
+          range: 10...30,
+          step: 1
+        )
+
+        Text("Debug only · Values reset when this screen closes")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+      .padding(20)
+      .frame(width: 320)
+      .tint(tint)
+    }
+
+    private func tuningSlider(
+      title: String,
+      valueText: String,
+      value: Binding<Double>,
+      range: ClosedRange<Double>,
+      step: Double
+    ) -> some View {
+      VStack(alignment: .leading, spacing: 6) {
+        HStack {
+          Text(title)
+            .font(.subheadline)
+
+          Spacer()
+
+          Text(valueText)
+            .font(.system(.caption, design: .monospaced, weight: .semibold))
+            .foregroundStyle(.secondary)
+        }
+
+        Slider(value: value, in: range, step: step)
+      }
+    }
+  }
+#endif
+
+private struct ActiveSessionPetalAnimation: View {
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+
+  let color: Color
+  let settings: ActiveSessionAnimationSettings
+  let timerTick: Int
+
+  private var petalCount: Int {
+    max(Int(settings.petalCount.rounded()), 1)
+  }
+
+  var body: some View {
+    GeometryReader { geometry in
+      let radiusX = max(geometry.size.width / 2 - 18, 0) * CGFloat(settings.bloomScale)
+      let radiusY = max(geometry.size.height / 2 - 18, 0) * CGFloat(settings.bloomScale)
+
+      ZStack {
+        ForEach(0..<petalCount, id: \.self) { index in
+          let petalAngle =
+            Double(index) / Double(petalCount) * 2 * Double.pi - Double.pi / 2
+          let breathing = breathingProgress(for: index, at: timerTick)
+          let horizontalRadius = CGFloat(cos(petalAngle)) * radiusX
+          let verticalRadius = CGFloat(sin(petalAngle)) * radiusY
+          let baseLength = hypot(horizontalRadius, verticalRadius)
+          let centerOpening = CGFloat(settings.centerOpening)
+          let restingLength = max(baseLength - centerOpening, 1)
+          let petalLength =
+            restingLength * CGFloat(settings.petalLength) * (0.94 + 0.12 * breathing)
+          let petalWidth = (52 + 8 * breathing) * CGFloat(settings.petalWidth)
+          let petalCenterRadius = centerOpening + petalLength / 2
+
+          ActiveSessionRosePetalShape()
+            .fill(
+              LinearGradient(
+                stops: [
+                  .init(color: color.opacity(0.88), location: 0),
+                  .init(color: color.opacity(0.54), location: 0.5),
+                  .init(color: color.opacity(0.1), location: 1),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+              )
+            )
+            .frame(
+              width: petalWidth,
+              height: petalLength
+            )
+            .rotationEffect(.radians(petalAngle + Double.pi / 2))
+            .position(
+              x: geometry.size.width / 2
+                + CGFloat(cos(petalAngle)) * petalCenterRadius,
+              y: geometry.size.height / 2
+                + CGFloat(sin(petalAngle)) * petalCenterRadius
+            )
+            .opacity(
+              min((0.48 + 0.18 * Double(breathing)) * settings.visibility, 0.82)
+            )
+            .blur(radius: 0.8)
+            .zIndex(Double(breathing))
+        }
+      }
+      .drawingGroup()
+      .animation(accessibilityReduceMotion ? nil : .default, value: timerTick)
+    }
+    .allowsHitTesting(false)
+    .accessibilityHidden(true)
+  }
+
+  private func breathingProgress(for index: Int, at timerTick: Int) -> CGFloat {
+    guard !accessibilityReduceMotion else { return 0 }
+
+    let cycleDuration = max(Int(settings.breathingDuration.rounded()), 1)
+    let cycleTick = timerTick % cycleDuration
+    let cycleProgress = Double(cycleTick) / Double(cycleDuration)
+    let petalProgress = cycleProgress * Double(petalCount)
+    let activePetal = min(Int(petalProgress), petalCount - 1)
+
+    guard index == activePetal else { return 0 }
+
+    let localProgress = petalProgress - Double(activePetal)
+    return CGFloat((1 - cos(localProgress * 2 * Double.pi)) / 2)
+  }
+}
+
+private struct ActiveSessionRosePetalShape: Shape {
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    path.move(to: CGPoint(x: rect.midX, y: rect.maxY))
+    path.addCurve(
+      to: CGPoint(x: rect.minX + rect.width * 0.08, y: rect.minY + rect.height * 0.38),
+      control1: CGPoint(x: rect.minX + rect.width * 0.25, y: rect.minY + rect.height * 0.86),
+      control2: CGPoint(x: rect.minX + rect.width * 0.02, y: rect.minY + rect.height * 0.65)
+    )
+    path.addCurve(
+      to: CGPoint(x: rect.midX, y: rect.minY + rect.height * 0.05),
+      control1: CGPoint(x: rect.minX + rect.width * 0.05, y: rect.minY + rect.height * 0.16),
+      control2: CGPoint(x: rect.minX + rect.width * 0.3, y: rect.minY + rect.height * 0.02)
+    )
+    path.addCurve(
+      to: CGPoint(x: rect.maxX - rect.width * 0.08, y: rect.minY + rect.height * 0.38),
+      control1: CGPoint(x: rect.maxX - rect.width * 0.3, y: rect.minY + rect.height * 0.02),
+      control2: CGPoint(x: rect.maxX - rect.width * 0.05, y: rect.minY + rect.height * 0.16)
+    )
+    path.addCurve(
+      to: CGPoint(x: rect.midX, y: rect.maxY),
+      control1: CGPoint(x: rect.maxX - rect.width * 0.02, y: rect.minY + rect.height * 0.65),
+      control2: CGPoint(x: rect.maxX - rect.width * 0.25, y: rect.minY + rect.height * 0.86)
+    )
+    path.closeSubpath()
+    return path
+  }
+}
+
+private enum SoftUnblockActiveGrantResource {
+  case stored(SoftUnblockResource)
+  case preview(title: String, systemImageName: String)
+}
+
+private struct SoftUnblockActiveGrantDisplay: Identifiable {
+  let id: UUID
+  let resource: SoftUnblockActiveGrantResource
+  let createdAt: Date
+  let expiresAt: Date
+
+  init(grant: SoftUnblockGrant) {
+    id = grant.id
+    resource = .stored(grant.resource)
+    createdAt = grant.createdAt
+    expiresAt = grant.expiresAt
+  }
+
+  init(
+    id: UUID,
+    title: String,
+    systemImageName: String,
+    createdAt: Date,
+    expiresAt: Date
+  ) {
+    self.id = id
+    resource = .preview(title: title, systemImageName: systemImageName)
+    self.createdAt = createdAt
+    self.expiresAt = expiresAt
+  }
+}
+
+private enum SoftUnblockActiveGrantsSource {
+  case live
+  case preview([SoftUnblockActiveGrantDisplay])
+
+  func activeGrants(for profileId: UUID, at date: Date) -> [SoftUnblockActiveGrantDisplay] {
+    switch self {
+    case .live:
+      return SoftUnblockGrantStore.activeGrants(for: profileId, at: date).map {
+        SoftUnblockActiveGrantDisplay(grant: $0)
+      }
+    case .preview(let grants):
+      return grants.filter { $0.expiresAt > date }
+    }
+  }
+}
+
+private struct SoftUnblockActiveGrantsSourceKey: EnvironmentKey {
+  static let defaultValue = SoftUnblockActiveGrantsSource.live
+}
+
+extension EnvironmentValues {
+  fileprivate var softUnblockActiveGrantsSource: SoftUnblockActiveGrantsSource {
+    get { self[SoftUnblockActiveGrantsSourceKey.self] }
+    set { self[SoftUnblockActiveGrantsSourceKey.self] = newValue }
+  }
+}
+
 private struct SoftUnblockActiveGrantsCard: View {
   private static let visibleGrantLimit = 3
+
+  @Environment(\.softUnblockActiveGrantsSource) private var activeGrantsSource
 
   let profileId: UUID
 
   var body: some View {
     TimelineView(.periodic(from: .now, by: 1)) { timeline in
-      let activeGrants = SoftUnblockGrantStore.activeGrants(
-        for: profileId,
-        at: timeline.date
-      )
-      .sorted { lhs, rhs in
-        if lhs.expiresAt == rhs.expiresAt {
-          return lhs.createdAt < rhs.createdAt
+      let activeGrants = activeGrantsSource.activeGrants(for: profileId, at: timeline.date)
+        .sorted { lhs, rhs in
+          if lhs.expiresAt == rhs.expiresAt {
+            return lhs.createdAt < rhs.createdAt
+          }
+          return lhs.expiresAt < rhs.expiresAt
         }
-        return lhs.expiresAt < rhs.expiresAt
-      }
       let visibleGrants = Array(activeGrants.prefix(Self.visibleGrantLimit))
       let overflowCount = activeGrants.count - visibleGrants.count
 
       if !activeGrants.isEmpty {
-        VStack(spacing: 0) {
-          ForEach(Array(visibleGrants.enumerated()), id: \.element.id) { index, grant in
-            if index > 0 {
-              Divider()
-                .opacity(0.45)
-            }
-
+        VStack(spacing: 4) {
+          ForEach(visibleGrants) { grant in
             SoftUnblockActiveGrantRow(
               grant: grant,
               date: timeline.date
@@ -334,26 +693,20 @@ private struct SoftUnblockActiveGrantsCard: View {
           }
 
           if overflowCount > 0 {
-            Divider()
-              .opacity(0.45)
-
             Text("+\(overflowCount) more active")
-              .font(.footnote)
-              .fontWeight(.semibold)
+              .font(.caption)
+              .fontWeight(.medium)
               .foregroundStyle(.secondary)
               .frame(maxWidth: .infinity, alignment: .leading)
-              .padding(.vertical, 10)
+              .padding(.top, 4)
           }
         }
-        .padding(16)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
         .background(
-          .thinMaterial,
-          in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+          Color.primary.opacity(0.045),
+          in: RoundedRectangle(cornerRadius: 16, style: .continuous)
         )
-        .overlay {
-          RoundedRectangle(cornerRadius: 20, style: .continuous)
-            .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
-        }
         .transition(.move(edge: .bottom).combined(with: .opacity))
         .animation(.easeInOut(duration: 0.25), value: activeGrants.map(\.id))
       }
@@ -362,7 +715,7 @@ private struct SoftUnblockActiveGrantsCard: View {
 }
 
 private struct SoftUnblockActiveGrantRow: View {
-  let grant: SoftUnblockGrant
+  let grant: SoftUnblockActiveGrantDisplay
   let date: Date
 
   private var remainingSeconds: Int {
@@ -386,30 +739,33 @@ private struct SoftUnblockActiveGrantRow: View {
   }
 
   var body: some View {
-    HStack(spacing: 12) {
+    HStack(spacing: 10) {
       resourceLabel
         .font(.subheadline)
-        .fontWeight(.semibold)
+        .fontWeight(.medium)
         .lineLimit(1)
         .minimumScaleFactor(0.8)
 
       Spacer(minLength: 8)
 
       Text(countdownText)
-        .font(.system(.subheadline, design: .monospaced, weight: .bold))
+        .font(.system(.footnote, design: .monospaced, weight: .semibold))
+        .foregroundStyle(.secondary)
         .contentTransition(.numericText(countsDown: true))
         .accessibilityLabel(accessibilityCountdownText)
     }
-    .padding(.vertical, 10)
+    .padding(.vertical, 6)
   }
 
   @ViewBuilder
   private var resourceLabel: some View {
     switch grant.resource {
-    case .application(let token):
+    case .stored(.application(let token)):
       Label(token)
-    case .category(let token):
+    case .stored(.category(let token)):
       Label(token)
+    case .preview(let title, let systemImageName):
+      Label(title, systemImage: systemImageName)
     }
   }
 }
@@ -522,7 +878,7 @@ private struct ActiveSessionPressStyle: ButtonStyle {
   }
 }
 
-#Preview {
+#Preview("Standard Session") {
   ActiveProfileSessionView(
     profile: BlockedProfiles(name: "Work Focus"),
     elapsedTime: 3665,
@@ -536,4 +892,101 @@ private struct ActiveSessionPressStyle: ButtonStyle {
     onExpiredCountdownReset: {}
   )
   .environmentObject(StrategyManager())
+  .environmentObject(ThemeManager())
+}
+
+#Preview("Temporary Access · One App") {
+  let previewDate = Date()
+  let profile = BlockedProfiles(
+    id: UUID(uuidString: "8C58F66A-1F6E-45D7-97CC-95756AB663C2")!,
+    name: "Deep Work",
+    blockingStrategyId: NFCSoftUnblockBlockingStrategy.id,
+    enableBreaks: false
+  )
+
+  ActiveProfileSessionView(
+    profile: profile,
+    elapsedTime: 733,
+    displayTime: 733,
+    isBreakAvailable: false,
+    isBreakActive: false,
+    isPauseActive: false,
+    isCountdownExpired: false,
+    onBreakTapped: {},
+    onStopTapped: {},
+    onExpiredCountdownReset: {}
+  )
+  .environment(
+    \.softUnblockActiveGrantsSource,
+    .preview([
+      SoftUnblockActiveGrantDisplay(
+        id: UUID(uuidString: "B0C1B326-E87C-4692-BE1E-04AEEDC04880")!,
+        title: "Instagram",
+        systemImageName: "camera.fill",
+        createdAt: previewDate.addingTimeInterval(-38),
+        expiresAt: previewDate.addingTimeInterval(262)
+      )
+    ])
+  )
+  .environmentObject(StrategyManager())
+  .environmentObject(ThemeManager())
+}
+
+#Preview("Temporary Access · Multiple") {
+  let previewDate = Date()
+  let profile = BlockedProfiles(
+    id: UUID(uuidString: "31C8D175-A37C-4C82-919E-6BB06E9C9B6B")!,
+    name: "Study Session",
+    blockingStrategyId: QRSoftUnblockBlockingStrategy.id,
+    enableBreaks: false
+  )
+
+  ActiveProfileSessionView(
+    profile: profile,
+    elapsedTime: 1_254,
+    displayTime: 1_254,
+    isBreakAvailable: false,
+    isBreakActive: false,
+    isPauseActive: false,
+    isCountdownExpired: false,
+    onBreakTapped: {},
+    onStopTapped: {},
+    onExpiredCountdownReset: {}
+  )
+  .environment(
+    \.softUnblockActiveGrantsSource,
+    .preview([
+      SoftUnblockActiveGrantDisplay(
+        id: UUID(uuidString: "B00A56CF-F936-4B5C-875C-77943D503961")!,
+        title: "Instagram",
+        systemImageName: "camera.fill",
+        createdAt: previewDate.addingTimeInterval(-61),
+        expiresAt: previewDate.addingTimeInterval(119)
+      ),
+      SoftUnblockActiveGrantDisplay(
+        id: UUID(uuidString: "7921AAAF-DCC0-41CC-82BC-8E5291C53B65")!,
+        title: "Social",
+        systemImageName: "person.2.fill",
+        createdAt: previewDate.addingTimeInterval(-28),
+        expiresAt: previewDate.addingTimeInterval(212)
+      ),
+      SoftUnblockActiveGrantDisplay(
+        id: UUID(uuidString: "A792D79C-E42C-498F-9DEE-CA417F13D398")!,
+        title: "YouTube",
+        systemImageName: "play.rectangle.fill",
+        createdAt: previewDate.addingTimeInterval(-23),
+        expiresAt: previewDate.addingTimeInterval(397)
+      ),
+      SoftUnblockActiveGrantDisplay(
+        id: UUID(uuidString: "41764C6B-1592-4A15-BB7E-8F5CB827B4BC")!,
+        title: "Entertainment",
+        systemImageName: "film.fill",
+        createdAt: previewDate.addingTimeInterval(-10),
+        expiresAt: previewDate.addingTimeInterval(530)
+      ),
+    ])
+  )
+  .environmentObject(StrategyManager())
+  .environmentObject(ThemeManager())
+  .preferredColorScheme(.dark)
 }

--- a/Foqos/Views/ActiveProfileSessionView.swift
+++ b/Foqos/Views/ActiveProfileSessionView.swift
@@ -3,10 +3,8 @@ import SwiftUI
 import UIKit
 
 struct ActiveProfileSessionView: View {
-  @Environment(\.colorScheme) private var colorScheme
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var strategyManager: StrategyManager
-  @EnvironmentObject private var themeManager: ThemeManager
 
   let profile: BlockedProfiles
   let elapsedTime: TimeInterval
@@ -20,7 +18,6 @@ struct ActiveProfileSessionView: View {
   let onExpiredCountdownReset: () -> Void
 
   @State private var showEmergencyView = false
-  @State private var showProfileInsights = false
   @State private var showingAlert = false
   @State private var alertMessage = ""
   @State private var focusMessageIndex = Self.initialFocusMessageIndex()
@@ -68,38 +65,28 @@ struct ActiveProfileSessionView: View {
     ].contains(strategyId)
   }
 
-  private var supportingTextColor: Color {
-    colorScheme == .dark ? Color.white.opacity(0.78) : Color.black.opacity(0.66)
-  }
-
   var body: some View {
-    ZStack {
-      background
+    VStack(alignment: .leading, spacing: 0) {
+      topControls
 
-      VStack(alignment: .leading, spacing: 0) {
-        header
+      Spacer(minLength: 24)
 
-        ScrollView {
-          timerSection
-            .padding(.top, 60)
-            .padding(.bottom, 36)
-            .frame(maxWidth: .infinity)
-        }
-        .scrollIndicators(.hidden)
-        .scrollBounceBehavior(.basedOnSize)
+      timer
+        .frame(maxWidth: .infinity)
 
+      Spacer(minLength: 24)
+
+      VStack(alignment: .leading, spacing: 18) {
+        profileDetails
         actionSection
       }
-      .padding(.horizontal, 24)
-      .padding(.top, 18)
-      .padding(.bottom, 20)
     }
+    .padding(.horizontal, 20)
+    .padding(.top, 8)
+    .padding(.bottom, 16)
     .sheet(isPresented: $showEmergencyView) {
       EmergencyView()
         .presentationDetents([.height(350), .large])
-    }
-    .sheet(isPresented: $showProfileInsights) {
-      ProfileInsightsView(profile: profile)
     }
     .sheet(isPresented: $strategyManager.showCustomStrategyView) {
       BlockingStrategyActionView(
@@ -124,72 +111,35 @@ struct ActiveProfileSessionView: View {
     }
   }
 
-  private var background: some View {
-    ZStack {
-      ActiveSessionGradientBackground(baseColor: themeManager.themeColor)
+  private var topControls: some View {
+    HStack {
+      if #available(iOS 26.0, *) {
+        closeButton
+          .buttonStyle(.glass)
+          .buttonBorderShape(.circle)
+      } else {
+        closeButton
+          .background(.ultraThinMaterial, in: Circle())
+          .overlay {
+            Circle()
+              .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
+          }
+          .buttonStyle(ActiveSessionPressStyle())
+      }
 
-      LinearGradient(
-        colors: [
-          Color(.systemBackground).opacity(0.02),
-          Color(.systemBackground).opacity(0.34),
-        ],
-        startPoint: .top,
-        endPoint: .bottom
-      )
-      .ignoresSafeArea()
+      Spacer()
     }
   }
 
-  private var header: some View {
-    HStack(alignment: .top, spacing: 16) {
-      VStack(alignment: .leading, spacing: 8) {
-        Text(profile.name)
-          .font(.largeTitle)
-          .fontWeight(.bold)
-          .lineLimit(2)
-          .minimumScaleFactor(0.72)
-
-        if let statusMessage, let statusIconName {
-          HStack(spacing: 6) {
-            Image(statusIconName)
-              .resizable()
-              .scaledToFit()
-              .frame(width: 18, height: 18)
-
-            Text(statusMessage)
-              .font(.subheadline)
-              .fontWeight(.semibold)
-              .foregroundStyle(.secondary)
-          }
-        }
-      }
-
-      Spacer(minLength: 12)
-
-      HStack(spacing: 10) {
-        Button(action: { showProfileInsights = true }) {
-          Image(systemName: "chart.line.uptrend.xyaxis")
-            .font(.system(size: 16, weight: .semibold))
-            .frame(width: 42, height: 42)
-            .background(.thinMaterial, in: Circle())
-            .contentShape(Circle())
-        }
-        .buttonStyle(ActiveSessionPressStyle())
-        .foregroundStyle(.primary)
-        .accessibilityLabel("Insights")
-
-        Button(action: { dismiss() }) {
-          Image(systemName: "xmark")
-            .font(.system(size: 15, weight: .semibold))
-            .frame(width: 42, height: 42)
-            .background(.thinMaterial, in: Circle())
-            .contentShape(Circle())
-        }
-        .buttonStyle(ActiveSessionPressStyle())
-        .foregroundStyle(.primary)
-        .accessibilityLabel("Close")
-      }
+  private var closeButton: some View {
+    Button(action: { dismiss() }) {
+      Image(systemName: "xmark")
+        .font(.system(size: 18, weight: .semibold))
+        .frame(width: 40, height: 40)
+        .contentShape(Circle())
     }
+    .foregroundStyle(.primary)
+    .accessibilityLabel("Close")
   }
 
   private var statusMessage: String? {
@@ -212,43 +162,67 @@ struct ActiveProfileSessionView: View {
     return nil
   }
 
-  private var timerSection: some View {
-    VStack(spacing: 14) {
-      HStack(spacing: 8) {
-        BlockingStrategyIconImage(strategy: blockingStrategy)
-          .font(.system(size: 20, weight: .semibold))
-          .foregroundStyle(.primary)
-          .frame(width: 50, height: 50)
-          .accessibilityHidden(true)
+  private var timer: some View {
+    Text(DateFormatters.formatDurationClock(displayTime))
+      .font(.system(size: 64, weight: .bold, design: .monospaced))
+      .lineLimit(1)
+      .minimumScaleFactor(0.5)
+      .contentTransition(.numericText())
+      .animation(.default, value: displayTime)
+      .accessibilityLabel("Session time")
+      .accessibilityValue(DateFormatters.formatDurationClock(displayTime))
+  }
 
-        Text(strategyName)
-          .font(.headline)
-          .fontWeight(.bold)
-          .foregroundStyle(supportingTextColor)
+  private var profileDetails: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(profile.name)
+        .font(.title3)
+        .fontWeight(.bold)
+        .lineLimit(2)
+
+      HStack(spacing: 12) {
+        HStack(spacing: 6) {
+          BlockingStrategyIconImage(strategy: blockingStrategy)
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .frame(width: 20, height: 20)
+            .accessibilityHidden(true)
+
+          Text(strategyName)
+            .font(.subheadline)
+            .fontWeight(.semibold)
+            .foregroundStyle(.secondary)
+        }
+
+        if let statusMessage, let statusIconName {
+          HStack(spacing: 5) {
+            Image(statusIconName)
+              .resizable()
+              .scaledToFit()
+              .frame(width: 16, height: 16)
+
+            Text(statusMessage)
+              .font(.subheadline)
+              .fontWeight(.semibold)
+              .foregroundStyle(.secondary)
+          }
+        }
       }
 
-      Text(DateFormatters.formatDurationClock(displayTime))
-        .font(.system(size: 58, weight: .bold, design: .monospaced))
-        .lineLimit(1)
-        .minimumScaleFactor(0.55)
-        .contentTransition(.numericText())
-        .animation(.default, value: displayTime)
-
       Text(focusMessage)
-        .font(.headline)
-        .fontWeight(.bold)
-        .foregroundStyle(supportingTextColor)
-        .multilineTextAlignment(.center)
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.leading)
         .lineLimit(2)
         .contentTransition(.opacity)
         .animation(.easeInOut(duration: 0.35), value: focusMessage)
 
       if isSoftUnblockStrategy {
         SoftUnblockActiveGrantsCard(profileId: profile.id)
-          .padding(.top, 16)
+          .padding(.top, 4)
       }
     }
-    .padding(.horizontal, 12)
+    .frame(maxWidth: .infinity, alignment: .leading)
   }
 
   private var actionSection: some View {
@@ -258,8 +232,9 @@ struct ActiveProfileSessionView: View {
           Text("This timer finished, but the session is still active.")
             .font(.footnote)
             .fontWeight(.semibold)
-            .foregroundStyle(supportingTextColor)
-            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
           ActiveSessionActionButton(
             title: "Reset Session",
@@ -439,147 +414,6 @@ private struct SoftUnblockActiveGrantRow: View {
   }
 }
 
-private struct ActiveSessionGradientBackground: View {
-  let baseColor: Color
-
-  var body: some View {
-    TimelineView(.animation) { timeline in
-      let t = timeline.date.timeIntervalSinceReferenceDate
-
-      ZStack {
-        LinearGradient(
-          colors: [
-            shiftedColor(hue: -0.08, saturation: 1.22, brightness: 0.95),
-            shiftedColor(hue: 0.02, saturation: 1.1, brightness: 0.82),
-            shiftedColor(hue: 0.10, saturation: 1.18, brightness: 0.64),
-          ],
-          startPoint: UnitPoint(
-            x: 0.18 + 0.18 * normalizedSin(t * 0.08),
-            y: 0.02
-          ),
-          endPoint: UnitPoint(
-            x: 0.88,
-            y: 0.92 - 0.16 * normalizedCos(t * 0.07)
-          )
-        )
-
-        animatedBlob(
-          t: t,
-          hue: 0.09,
-          saturation: 1.35,
-          brightness: 1.1,
-          opacity: 0.48,
-          width: 0.86,
-          height: 0.42,
-          x: 0.18 + 0.18 * normalizedCos(t * 0.12),
-          y: 0.62 + 0.08 * normalizedSin(t * 0.10),
-          blur: 34
-        )
-
-        animatedBlob(
-          t: t,
-          hue: -0.12,
-          saturation: 1.18,
-          brightness: 0.92,
-          opacity: 0.42,
-          width: 0.72,
-          height: 0.50,
-          x: 0.84 - 0.20 * normalizedSin(t * 0.09),
-          y: 0.72 + 0.10 * normalizedCos(t * 0.11),
-          blur: 42
-        )
-
-        animatedBlob(
-          t: t,
-          hue: 0.16,
-          saturation: 1.28,
-          brightness: 0.78,
-          opacity: 0.38,
-          width: 0.98,
-          height: 0.46,
-          x: 0.52 + 0.16 * normalizedSin(t * 0.07),
-          y: 0.92 - 0.10 * normalizedCos(t * 0.13),
-          blur: 46
-        )
-
-        Rectangle()
-          .fill(Color.black.opacity(0.10))
-      }
-      .ignoresSafeArea()
-    }
-  }
-
-  private func animatedBlob(
-    t: TimeInterval,
-    hue: Double,
-    saturation: Double,
-    brightness: Double,
-    opacity: Double,
-    width: CGFloat,
-    height: CGFloat,
-    x: CGFloat,
-    y: CGFloat,
-    blur: CGFloat
-  ) -> some View {
-    GeometryReader { geometry in
-      Ellipse()
-        .fill(
-          RadialGradient(
-            colors: [
-              shiftedColor(hue: hue, saturation: saturation, brightness: brightness).opacity(
-                opacity),
-              .clear,
-            ],
-            center: .center,
-            startRadius: 0,
-            endRadius: min(geometry.size.width, geometry.size.height) * 0.42
-          )
-        )
-        .frame(
-          width: geometry.size.width * width,
-          height: geometry.size.height * height
-        )
-        .position(
-          x: geometry.size.width * x,
-          y: geometry.size.height * y
-        )
-        .blur(radius: blur)
-        .scaleEffect(0.94 + 0.10 * normalizedSin(t * 0.18 + Double(width)))
-        .blendMode(.plusLighter)
-    }
-  }
-
-  private func shiftedColor(hue: Double, saturation: Double, brightness: Double) -> Color {
-    let ui = UIColor(baseColor)
-    var h: CGFloat = 0
-    var s: CGFloat = 0
-    var b: CGFloat = 0
-    var a: CGFloat = 0
-
-    if ui.getHue(&h, saturation: &s, brightness: &b, alpha: &a) {
-      let shiftedHue = (h + CGFloat(hue)).truncatingRemainder(dividingBy: 1)
-      return Color(
-        UIColor(
-          hue: shiftedHue < 0 ? shiftedHue + 1 : shiftedHue,
-          saturation: min(1, max(0, s * CGFloat(saturation))),
-          brightness: min(1, max(0, b * CGFloat(brightness))),
-          alpha: a
-        )
-      )
-    }
-
-    return baseColor
-  }
-
-  private func normalizedSin(_ value: Double) -> CGFloat {
-    CGFloat((sin(value) + 1) / 2)
-  }
-
-  private func normalizedCos(_ value: Double) -> CGFloat {
-    CGFloat((cos(value) + 1) / 2)
-  }
-}
-
 private enum ActiveSessionActionRole {
   case standard
   case warning
@@ -604,6 +438,15 @@ private struct ActiveSessionActionButton: View {
       return .orange
     case .destructive:
       return .red
+    }
+  }
+
+  private var backgroundOpacity: Double {
+    switch role {
+    case .standard:
+      return 0.08
+    case .warning, .destructive:
+      return 0.12
     }
   }
 
@@ -634,20 +477,19 @@ private struct ActiveSessionActionButton: View {
       icon
 
       Text(title)
-        .font(.headline)
+        .font(.subheadline)
         .fontWeight(.semibold)
         .lineLimit(1)
         .minimumScaleFactor(0.82)
     }
     .frame(maxWidth: .infinity)
-    .frame(height: 56)
+    .frame(height: 48)
     .foregroundStyle(foregroundColor)
-    .background(.thinMaterial, in: Capsule())
-    .overlay(
-      Capsule()
-        .strokeBorder(foregroundColor.opacity(0.22), lineWidth: 1)
+    .background(
+      foregroundColor.opacity(backgroundOpacity),
+      in: RoundedRectangle(cornerRadius: 14, style: .continuous)
     )
-    .contentShape(Capsule())
+    .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
   }
 
   @ViewBuilder
@@ -694,5 +536,4 @@ private struct ActiveSessionPressStyle: ButtonStyle {
     onExpiredCountdownReset: {}
   )
   .environmentObject(StrategyManager())
-  .environmentObject(ThemeManager.shared)
 }

--- a/Foqos/Views/ActiveProfileSessionView.swift
+++ b/Foqos/Views/ActiveProfileSessionView.swift
@@ -810,8 +810,8 @@ private struct ActiveSessionActionButton: View {
     Group {
       if requiresLongPress {
         label
-          .scaleEffect(isPressed ? 0.97 : 1)
-          .animation(.spring(response: 0.24, dampingFraction: 0.74), value: isPressed)
+          .scaleEffect(isPressed ? 0.95 : 1)
+          .animation(.spring(response: 0.22, dampingFraction: 0.72), value: isPressed)
           .onLongPressGesture(
             minimumDuration: 0.8,
             pressing: { pressing in
@@ -829,23 +829,23 @@ private struct ActiveSessionActionButton: View {
   }
 
   private var label: some View {
-    HStack(spacing: 8) {
+    HStack(spacing: 10) {
       icon
 
       Text(title)
-        .font(.subheadline)
+        .font(.headline)
         .fontWeight(.semibold)
         .lineLimit(1)
-        .minimumScaleFactor(0.82)
+        .minimumScaleFactor(0.76)
     }
     .frame(maxWidth: .infinity)
-    .frame(height: 48)
+    .frame(height: 58)
     .foregroundStyle(foregroundColor)
     .background(
       foregroundColor.opacity(backgroundOpacity),
-      in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+      in: Capsule()
     )
-    .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    .contentShape(Capsule())
   }
 
   @ViewBuilder
@@ -857,7 +857,7 @@ private struct ActiveSessionActionButton: View {
         .frame(width: 24, height: 24)
     } else {
       Image(systemName: iconName)
-        .font(.system(size: 15, weight: .bold))
+        .font(.system(size: 17, weight: .bold))
     }
   }
 
@@ -870,9 +870,9 @@ private struct ActiveSessionActionButton: View {
 private struct ActiveSessionPressStyle: ButtonStyle {
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
-      .scaleEffect(configuration.isPressed ? 0.96 : 1)
+      .scaleEffect(configuration.isPressed ? 0.95 : 1)
       .animation(
-        .spring(response: 0.24, dampingFraction: 0.74),
+        .spring(response: 0.22, dampingFraction: 0.72),
         value: configuration.isPressed
       )
   }


### PR DESCRIPTION
## Summary
- refocus the active session around a clean timer with a configurable rose-petal bloom
- synchronize sequential petal breathing with the one-second session timer and respect Reduced Motion
- simplify temporary-access grant rows and add isolated single- and multi-grant previews
- replace rectangular session actions with larger capsule buttons consistent with the app launcher

## Verification
- make build
- swift-format lint Foqos/Views/ActiveProfileSessionView.swift
- git diff --check HEAD