### PR TITLE
Add Wi-Fi based app blocking feature

### DIFF
--- a/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
@@ -21,6 +21,9 @@ final class BlockedProfileDraft: ObservableObject {
   @Published var enableMacSync: Bool
   @Published var disableBackgroundStops: Bool
   @Published var enableEmergencyUnblock: Bool
+  @Published var enableWiFiBlocking: Bool
+  @Published var wifiSSIDs: [String]
+  @Published var allowManualControl: Bool
   @Published var domains: [String]
   @Published var physicalUnblockItems: [PhysicalUnblockItem]
   @Published var schedule: BlockedProfileSchedule
@@ -61,6 +64,9 @@ final class BlockedProfileDraft: ObservableObject {
     enableReminder = profile?.reminderTimeInSeconds != nil
     disableBackgroundStops = profile?.disableBackgroundStops ?? false
     enableEmergencyUnblock = profile?.enableEmergencyUnblock ?? true
+    enableWiFiBlocking = profile?.enableWiFiBlocking ?? false
+    wifiSSIDs = profile?.wifiSSIDs ?? []
+    allowManualControl = profile?.allowManualControl ?? true
     reminderTimeInMinutes = Int(profile?.reminderTimeInSeconds ?? 900) / 60
     customReminderMessage = profile?.customReminderMessage ?? ""
     domains = profile?.domains ?? []
@@ -138,7 +144,10 @@ final class BlockedProfileDraft: ObservableObject {
         physicalUnblockItems: .some(physicalUnblockItemsToSave),
         schedule: schedule,
         disableBackgroundStops: disableBackgroundStops,
-        enableEmergencyUnblock: enableEmergencyUnblock
+        enableEmergencyUnblock: enableEmergencyUnblock,
+        enableWiFiBlocking: enableWiFiBlocking,
+        wifiSSIDs: wifiSSIDs,
+        allowManualControl: allowManualControl
       )
 
       DeviceActivityCenterUtil.scheduleTimerActivity(for: updatedProfile)
@@ -169,7 +178,10 @@ final class BlockedProfileDraft: ObservableObject {
       physicalUnblockItems: physicalUnblockItemsToSave,
       schedule: schedule,
       disableBackgroundStops: disableBackgroundStops,
-      enableEmergencyUnblock: enableEmergencyUnblock
+      enableEmergencyUnblock: enableEmergencyUnblock,
+      enableWiFiBlocking: enableWiFiBlocking,
+      wifiSSIDs: wifiSSIDs,
+      allowManualControl: allowManualControl
     )
 
     DeviceActivityCenterUtil.scheduleTimerActivity(for: newProfile)

--- a/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
@@ -11,6 +11,114 @@ private struct ProfileFieldDivider: View {
   }
 }
 
+struct BlockedProfileWiFiFields: View {
+  @EnvironmentObject private var themeManager: ThemeManager
+  @ObservedObject var draft: BlockedProfileDraft
+  var disabled: Bool
+  var showsSeparators: Bool = false
+
+  @State private var newSSID: String = ""
+  @StateObject private var wifiMonitor = WiFiMonitorManager.shared
+
+  var body: some View {
+    CustomToggle(
+      title: "Enable Wi-Fi Blocking",
+      description: "Automatically start blocking when connected to specific Wi-Fi networks.",
+      isOn: $draft.enableWiFiBlocking,
+      isDisabled: disabled
+    )
+
+    if draft.enableWiFiBlocking {
+      ProfileFieldDivider(isVisible: showsSeparators)
+
+      VStack(alignment: .leading, spacing: 8) {
+        HStack {
+          TextField("Enter Wi-Fi Network Name (SSID)", text: $newSSID)
+            .textFieldStyle(.roundedBorder)
+            .disabled(disabled)
+
+          Button("Add") {
+            let trimmed = newSSID.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty && !draft.wifiSSIDs.contains(trimmed) {
+              draft.wifiSSIDs.append(trimmed)
+              newSSID = ""
+            }
+          }
+          .disabled(disabled || newSSID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          .buttonStyle(.borderedProminent)
+          .tint(themeManager.themeColor)
+        }
+
+        if let current = wifiMonitor.currentSSID, !current.isEmpty {
+          Button("Use Current Wi-Fi (\(current))") {
+            if !draft.wifiSSIDs.contains(current) {
+              draft.wifiSSIDs.append(current)
+            }
+          }
+          .font(.caption)
+          .foregroundStyle(themeManager.themeColor)
+          .disabled(disabled)
+        }
+
+        if draft.wifiSSIDs.isEmpty {
+          Text("No Wi-Fi networks added yet.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(.top, 2)
+        } else {
+          ForEach(draft.wifiSSIDs, id: \.self) { ssid in
+            HStack {
+              Image(systemName: "wifi")
+                .foregroundStyle(themeManager.themeColor)
+              Text(ssid)
+              Spacer()
+              Button(role: .destructive) {
+                draft.wifiSSIDs.removeAll { $0 == ssid }
+              } label: {
+                Image(systemName: "trash")
+                  .foregroundStyle(.red)
+              }
+              .buttonStyle(.plain)
+              .disabled(disabled)
+            }
+            .padding(.vertical, 4)
+          }
+        }
+      }
+      .padding(.vertical, 4)
+
+      ProfileFieldDivider(isVisible: showsSeparators)
+
+      CustomToggle(
+        title: "Allow Manual Start/Stop",
+        description: "When turned off, session start and stop are strictly controlled by Wi-Fi status.",
+        isOn: $draft.allowManualControl,
+        isDisabled: disabled
+      )
+
+      if !wifiMonitor.isLocationAuthorized {
+        ProfileFieldDivider(isVisible: showsSeparators)
+        Button("Grant Location Access for Wi-Fi Detection") {
+          wifiMonitor.requestLocationAuthorization()
+        }
+        .font(.caption)
+        .foregroundStyle(themeManager.themeColor)
+      }
+    }
+  }
+}
+
+struct BlockedProfileWiFiSection: View {
+  @ObservedObject var draft: BlockedProfileDraft
+  var disabled: Bool
+
+  var body: some View {
+    Section("Wi-Fi Blocking") {
+      BlockedProfileWiFiFields(draft: draft, disabled: disabled)
+    }
+  }
+}
+
 struct BlockedProfileNameFields: View {
   @ObservedObject var draft: BlockedProfileDraft
   var disabled: Bool

--- a/Foqos/Info.plist
+++ b/Foqos/Info.plist
@@ -21,5 +21,7 @@
 		<string>fetch</string>
 		<string>processing</string>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Foqos requires location access to detect your connected Wi-Fi network name for Wi-Fi-based app blocking.</string>
 </dict>
 </plist>

--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -51,6 +51,10 @@ class BlockedProfiles {
 
   var enableEmergencyUnblock: Bool = true
 
+  var enableWiFiBlocking: Bool = false
+  var wifiSSIDs: [String]? = nil
+  var allowManualControl: Bool = true
+
   var customReminderMessage: String?
 
   @Relationship var sessions: [BlockedProfileSession] = []
@@ -125,7 +129,10 @@ class BlockedProfiles {
     physicalUnblockItems: [PhysicalUnblockItem]? = nil,
     schedule: BlockedProfileSchedule? = nil,
     disableBackgroundStops: Bool = false,
-    enableEmergencyUnblock: Bool = true
+    enableEmergencyUnblock: Bool = true,
+    enableWiFiBlocking: Bool = false,
+    wifiSSIDs: [String]? = nil,
+    allowManualControl: Bool = true
   ) {
     self.id = id
     self.name = name
@@ -158,6 +165,9 @@ class BlockedProfiles {
 
     self.disableBackgroundStops = disableBackgroundStops
     self.enableEmergencyUnblock = enableEmergencyUnblock
+    self.enableWiFiBlocking = enableWiFiBlocking
+    self.wifiSSIDs = wifiSSIDs
+    self.allowManualControl = allowManualControl
   }
 
   func showStopButton(elapsedTime: TimeInterval) -> Bool {
@@ -228,7 +238,10 @@ class BlockedProfiles {
     physicalUnblockItems: [PhysicalUnblockItem]?? = nil,
     schedule: BlockedProfileSchedule? = nil,
     disableBackgroundStops: Bool? = nil,
-    enableEmergencyUnblock: Bool? = nil
+    enableEmergencyUnblock: Bool? = nil,
+    enableWiFiBlocking: Bool? = nil,
+    wifiSSIDs: [String]? = nil,
+    allowManualControl: Bool? = nil
   ) throws -> BlockedProfiles {
     if let newName = name {
       profile.name = newName
@@ -334,6 +347,18 @@ class BlockedProfiles {
       profile.enableEmergencyUnblock = newEnableEmergencyUnblock
     }
 
+    if let newEnableWiFiBlocking = enableWiFiBlocking {
+      profile.enableWiFiBlocking = newEnableWiFiBlocking
+    }
+
+    if let newWifiSSIDs = wifiSSIDs {
+      profile.wifiSSIDs = newWifiSSIDs
+    }
+
+    if let newAllowManualControl = allowManualControl {
+      profile.allowManualControl = newAllowManualControl
+    }
+
     if let physicalUnblockItems {
       profile.physicalUnblockItems = PhysicalUnblockItem.normalizedItems(physicalUnblockItems)
     }
@@ -410,7 +435,10 @@ class BlockedProfiles {
       physicalUnblockItems: profile.physicalUnblockItems,
       schedule: profile.schedule,
       disableBackgroundStops: profile.disableBackgroundStops,
-      enableEmergencyUnblock: profile.enableEmergencyUnblock
+      enableEmergencyUnblock: profile.enableEmergencyUnblock,
+      enableWiFiBlocking: profile.enableWiFiBlocking,
+      wifiSSIDs: profile.wifiSSIDs,
+      allowManualControl: profile.allowManualControl
     )
   }
 
@@ -468,7 +496,10 @@ class BlockedProfiles {
     physicalUnblockItems: [PhysicalUnblockItem]? = nil,
     schedule: BlockedProfileSchedule? = nil,
     disableBackgroundStops: Bool = false,
-    enableEmergencyUnblock: Bool = true
+    enableEmergencyUnblock: Bool = true,
+    enableWiFiBlocking: Bool = false,
+    wifiSSIDs: [String]? = nil,
+    allowManualControl: Bool = true
   ) throws -> BlockedProfiles {
     let profileOrder = getNextOrder(in: context)
 
@@ -495,7 +526,10 @@ class BlockedProfiles {
       domains: domains,
       physicalUnblockItems: physicalUnblockItems,
       disableBackgroundStops: disableBackgroundStops,
-      enableEmergencyUnblock: enableEmergencyUnblock
+      enableEmergencyUnblock: enableEmergencyUnblock,
+      enableWiFiBlocking: enableWiFiBlocking,
+      wifiSSIDs: wifiSSIDs,
+      allowManualControl: allowManualControl
     )
 
     if let schedule = schedule {
@@ -539,7 +573,10 @@ class BlockedProfiles {
       domains: source.domains,
       physicalUnblockItems: source.physicalUnblockItems,
       schedule: source.schedule,
-      enableEmergencyUnblock: source.enableEmergencyUnblock
+      enableEmergencyUnblock: source.enableEmergencyUnblock,
+      enableWiFiBlocking: source.enableWiFiBlocking,
+      wifiSSIDs: source.wifiSSIDs,
+      allowManualControl: source.allowManualControl
     )
 
     context.insert(cloned)

--- a/Foqos/Models/Schedule.swift
+++ b/Foqos/Models/Schedule.swift
@@ -74,6 +74,21 @@ struct BlockedProfileSchedule: Codable, Equatable {
     return days.contains(today)
   }
 
+  func isCurrentlyActiveWindow(now: Date = Date(), calendar: Calendar = .current) -> Bool {
+    guard isActive, isTodayScheduled(now: now, calendar: calendar) else { return false }
+    let currentHour = calendar.component(.hour, from: now)
+    let currentMinute = calendar.component(.minute, from: now)
+    let currentTotalMinutes = currentHour * 60 + currentMinute
+    let startTotalMinutes = startHour * 60 + startMinute
+    let endTotalMinutes = endHour * 60 + endMinute
+
+    if startTotalMinutes <= endTotalMinutes {
+      return currentTotalMinutes >= startTotalMinutes && currentTotalMinutes < endTotalMinutes
+    } else {
+      return currentTotalMinutes >= startTotalMinutes || currentTotalMinutes < endTotalMinutes
+    }
+  }
+
   func olderThan15Minutes(now: Date = Date()) -> Bool {
     return now.timeIntervalSince(updatedAt) > 15 * 60
   }

--- a/Foqos/Models/Shared.swift
+++ b/Foqos/Models/Shared.swift
@@ -52,6 +52,9 @@ enum SharedData {
 
     var disableBackgroundStops: Bool?
     var enableEmergencyUnblock: Bool?
+    var enableWiFiBlocking: Bool?
+    var wifiSSIDs: [String]?
+    var allowManualControl: Bool?
   }
 
   // MARK: – Serializable snapshot of a session (no profile object)

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -77,6 +77,14 @@ class StrategyManager: ObservableObject {
   }
 
   func loadActiveSession(context: ModelContext) {
+    // Start Wi-Fi network monitoring if not already started
+    WiFiMonitorManager.shared.startMonitoring()
+    WiFiMonitorManager.shared.onSSIDChanged = { [weak self] _ in
+      DispatchQueue.main.async {
+        self?.evaluateWiFiBlocking(context: context)
+      }
+    }
+
     activeSession = getActiveSession(context: context)
     ActiveProfileSyncStore.publish(session: activeSession)
 
@@ -97,8 +105,53 @@ class StrategyManager: ObservableObject {
       liveActivityManager.endSessionActivity()
     }
 
+    // Evaluate Wi-Fi blocking rules
+    evaluateWiFiBlocking(context: context)
+
     // Reload widget to reflect any changes from extension (e.g., timer expiration)
     WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
+  }
+
+  func evaluateWiFiBlocking(context: ModelContext) {
+    guard let profiles = try? BlockedProfiles.fetchProfiles(in: context) else { return }
+    let currentSSID = WiFiMonitorManager.shared.currentSSID
+
+    for profile in profiles where profile.enableWiFiBlocking {
+      let ssids = profile.wifiSSIDs ?? []
+      let isSSIDMatch = currentSSID != nil && ssids.contains(where: { $0.caseInsensitiveCompare(currentSSID!) == .orderedSame })
+
+      let isScheduleActive: Bool
+      if let schedule = profile.schedule, schedule.isActive {
+        isScheduleActive = schedule.isCurrentlyActiveWindow()
+      } else {
+        isScheduleActive = true
+      }
+
+      let shouldBlockBeActive = isSSIDMatch && isScheduleActive
+      let profileID = profile.id
+
+      if let currentActive = activeSession, currentActive.blockedProfile.id == profileID {
+        if shouldBlockBeActive {
+          // Cancel any pending disconnect stop timer if Wi-Fi reconnected
+          WiFiMonitorManager.shared.cancelDisconnectStop(for: profileID)
+        } else {
+          // Schedule 1-minute grace period before stopping blocking session if not already scheduled
+          if !WiFiMonitorManager.shared.isDisconnectTimerPending(for: profileID) {
+            WiFiMonitorManager.shared.scheduleDisconnectStop(for: profileID) { [weak self] in
+              DispatchQueue.main.async {
+                guard let self = self, let session = self.activeSession, session.blockedProfile.id == profileID else { return }
+                let manualStrategy = self.getStrategy(id: ManualBlockingStrategy.id, context: context)
+                _ = manualStrategy.stopBlocking(context: context, session: session)
+              }
+            }
+          }
+        }
+      } else if shouldBlockBeActive && activeSession == nil {
+        // Automatically start blocking session for matching Wi-Fi
+        let manualStrategy = getStrategy(id: ManualBlockingStrategy.id, context: context)
+        _ = manualStrategy.startBlocking(context: context, profile: profile, forceStart: true)
+      }
+    }
   }
 
   func toggleBlocking(context: ModelContext, activeProfile: BlockedProfiles?) {
@@ -720,6 +773,11 @@ class StrategyManager: ObservableObject {
       return
     }
 
+    if definedProfile.enableWiFiBlocking && !definedProfile.allowManualControl {
+      self.errorMessage = "Manual control is disabled for this profile because Wi-Fi blocking is active."
+      return
+    }
+
     if let strategyId = definedProfile.blockingStrategyId {
       let strategy = getStrategy(id: strategyId, context: context)
       let view = strategy.startBlocking(
@@ -742,6 +800,11 @@ class StrategyManager: ObservableObject {
       print(
         "No active session found, calling stop blocking with no session"
       )
+      return
+    }
+
+    if session.blockedProfile.enableWiFiBlocking && !session.blockedProfile.allowManualControl {
+      self.errorMessage = "Manual control is disabled for this profile because Wi-Fi blocking is active."
       return
     }
 

--- a/Foqos/Utils/WiFiMonitorManager.swift
+++ b/Foqos/Utils/WiFiMonitorManager.swift
@@ -1,0 +1,104 @@
+import CoreLocation
+import Foundation
+import NetworkExtension
+import SystemConfiguration.CaptiveNetwork
+
+final class WiFiMonitorManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+  static let shared = WiFiMonitorManager()
+
+  @Published var currentSSID: String? = nil
+  @Published var isLocationAuthorized: Bool = false
+
+  private let locationManager = CLLocationManager()
+  private var monitorTimer: Timer?
+  private var disconnectTimers: [UUID: Timer] = [:]
+
+  override private init() {
+    super.init()
+    locationManager.delegate = self
+  }
+
+  func requestLocationAuthorization() {
+    locationManager.requestWhenInUseAuthorization()
+  }
+
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    let status = manager.authorizationStatus
+    DispatchQueue.main.async {
+      self.isLocationAuthorized = (status == .authorizedWhenInUse || status == .authorizedAlways)
+      self.fetchCurrentSSID()
+    }
+  }
+
+  func startMonitoring() {
+    stopMonitoring()
+    fetchCurrentSSID()
+
+    // Poll current SSID every 10 seconds
+    monitorTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
+      self?.fetchCurrentSSID()
+    }
+  }
+
+  func stopMonitoring() {
+    monitorTimer?.invalidate()
+    monitorTimer = nil
+  }
+
+  var onSSIDChanged: ((String?) -> Void)?
+
+  func fetchCurrentSSID(completion: ((String?) -> Void)? = nil) {
+    NEHotspotNetwork.fetchCurrent { hotspotNetwork in
+      let ssid = hotspotNetwork?.ssid
+      DispatchQueue.main.async {
+        let oldSSID = self.currentSSID
+        let newSSID: String?
+        if let ssid = ssid, !ssid.isEmpty {
+          newSSID = ssid
+        } else {
+          newSSID = self.fetchSSIDFallback()
+        }
+
+        self.currentSSID = newSSID
+        completion?(newSSID)
+
+        if oldSSID != newSSID {
+          self.onSSIDChanged?(newSSID)
+        }
+      }
+    }
+  }
+
+  private func fetchSSIDFallback() -> String? {
+    guard let interfaces = CNCopySupportedInterfaces() as? [String] else { return nil }
+    for interface in interfaces {
+      guard let interfaceInfo = CNCopyCurrentNetworkInfo(interface as CFString) as? [String: Any],
+        let ssid = interfaceInfo[kCNNetworkInfoKeySSID as String] as? String
+      else { continue }
+      return ssid
+    }
+    return nil
+  }
+
+  // MARK: - Disconnect Grace Period Management
+
+  func scheduleDisconnectStop(for profileID: UUID, onDisconnect: @escaping () -> Void) {
+    cancelDisconnectStop(for: profileID)
+
+    // Schedule 1-minute (60 seconds) grace period before stopping blocking
+    let timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: false) { [weak self] _ in
+      self?.disconnectTimers.removeValue(forKey: profileID)
+      onDisconnect()
+    }
+    disconnectTimers[profileID] = timer
+  }
+
+  func cancelDisconnectStop(for profileID: UUID) {
+    disconnectTimers[profileID]?.invalidate()
+    disconnectTimers.removeValue(forKey: profileID)
+  }
+
+  func isDisconnectTimerPending(for profileID: UUID) -> Bool {
+    return disconnectTimers[profileID] != nil
+  }
+}

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -122,6 +122,11 @@ struct BlockedProfileView: View {
           disabled: isBlocking
         )
 
+        BlockedProfileWiFiSection(
+          draft: draft,
+          disabled: isBlocking
+        )
+
         BlockedProfileBreaksSection(draft: draft, disabled: isBlocking)
 
         BlockedProfileStrictSafeguardsSection(draft: draft, disabled: isBlocking)

--- a/Foqos/foqos.entitlements
+++ b/Foqos/foqos.entitlements
@@ -8,6 +8,8 @@
 	</array>
 	<key>com.apple.developer.family-controls</key>
 	<true/>
+	<key>com.apple.developer.networking.wifi-info</key>
+	<true/>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
 		<string>TAG</string>

--- a/foqos.xcodeproj/project.pbxproj
+++ b/foqos.xcodeproj/project.pbxproj
@@ -1033,7 +1033,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosDeviceMonitor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1066,7 +1066,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosDeviceMonitor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1235,7 +1235,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1284,7 +1284,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1408,7 +1408,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosShieldConfig;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1436,7 +1436,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosShieldConfig;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1467,7 +1467,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1497,7 +1497,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1526,7 +1526,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosShieldAction;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1554,7 +1554,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.ambitionsoftware.foqos.FoqosShieldAction;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Adds Wi-Fi based app blocking to Foqos iOS app. Users can configure target Wi-Fi SSIDs for a profile, combine them with time schedules, enforce strict automatic Wi-Fi control, and benefit from a 1-minute grace period upon Wi-Fi disconnect.