### PR TITLE
Add active session info shortcut

### DIFF
--- a/Foqos/Intents/ActiveSessionInfoEntity.swift
+++ b/Foqos/Intents/ActiveSessionInfoEntity.swift
@@ -1,0 +1,48 @@
+import AppIntents
+import Foundation
+import SwiftData
+
+struct ActiveSessionInfoEntity: AppEntity, Identifiable {
+  var id: String
+
+  @Property(title: "Profile Name") var profileName: String
+  @Property(title: "Started At") var startedAt: Date
+  @Property(title: "Ends At") var endsAt: Date?
+
+  static var typeDisplayRepresentation = TypeDisplayRepresentation(
+    name: "Active Session Info"
+  )
+
+  static var defaultQuery = ActiveSessionInfoQuery()
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(profileName)")
+  }
+
+  init(session: BlockedProfileSession) {
+    id = session.id
+    profileName = session.blockedProfile.name
+    startedAt = session.startTime
+    endsAt = session.endTime ?? SessionTimeCalculator.expectedSessionEndTime(for: session)
+  }
+}
+
+struct ActiveSessionInfoQuery: EntityQuery {
+  @Dependency(key: "ModelContainer")
+  private var modelContainer: ModelContainer
+
+  @MainActor
+  private var modelContext: ModelContext {
+    return modelContainer.mainContext
+  }
+
+  @MainActor
+  func entities(for identifiers: [String]) async throws -> [ActiveSessionInfoEntity] {
+    let results = try modelContext.fetch(
+      FetchDescriptor<BlockedProfileSession>(
+        predicate: #Predicate { identifiers.contains($0.id) }
+      )
+    )
+    return results.map { ActiveSessionInfoEntity(session: $0) }
+  }
+}

--- a/Foqos/Intents/GetActiveSessionInfoIntent.swift
+++ b/Foqos/Intents/GetActiveSessionInfoIntent.swift
@@ -1,0 +1,40 @@
+import AppIntents
+import SwiftData
+
+struct GetActiveSessionInfoIntent: AppIntent {
+  @Dependency(key: "ModelContainer")
+  private var modelContainer: ModelContainer
+
+  @MainActor
+  private var modelContext: ModelContext {
+    return modelContainer.mainContext
+  }
+
+  static var title: LocalizedStringResource = "Get Active Session Info"
+  static var description = IntentDescription(
+    "Get the profile name, start date, and optional end date for the active Foqos session."
+  )
+
+  static var openAppWhenRun: Bool = false
+
+  @MainActor
+  func perform() async throws
+    -> some IntentResult & ReturnsValue<ActiveSessionInfoEntity?> & ProvidesDialog
+  {
+    let strategyManager = StrategyManager.shared
+    strategyManager.loadActiveSession(context: modelContext)
+
+    guard let activeSession = strategyManager.activeSession, activeSession.isActive else {
+      return .result(
+        value: Optional<ActiveSessionInfoEntity>.none,
+        dialog: "No Foqos session is active."
+      )
+    }
+
+    let sessionInfo = ActiveSessionInfoEntity(session: activeSession)
+    return .result(
+      value: Optional(sessionInfo),
+      dialog: "\(activeSession.blockedProfile.name) is active."
+    )
+  }
+}

--- a/Foqos/Utils/SessionTimeCalculator.swift
+++ b/Foqos/Utils/SessionTimeCalculator.swift
@@ -67,6 +67,10 @@ enum SessionTimeCalculator {
       return breakStartTime.addingTimeInterval(session.totalBreakAllowanceInSeconds)
     }
 
+    return expectedSessionEndTime(for: session)
+  }
+
+  static func expectedSessionEndTime(for session: BlockedProfileSession) -> Date? {
     if isScheduledSession(session), let schedule = session.blockedProfile.schedule {
       let durationInSeconds = schedule.totalDurationInSeconds
       guard durationInSeconds > 0 else { return nil }


### PR DESCRIPTION
## Summary
- add a new `Get Active Session Info` Shortcuts action
- return a compact session entity with Profile Name, Started At, and optional Ends At
- keep the existing boolean status action unchanged
- separate the stable session end calculation from break and pause countdown end times

## Behavior
- returns no value with a dialog when no session is active
- returns Ends At for timer and scheduled sessions
- leaves Ends At empty for open-ended sessions

## Validation
- `make build`
- App Intents metadata extraction verified the action and all three properties
- touched files pass `swift-format lint`

Closes #482