### PR TITLE
Fix shared profile snapshot decoding across app upgrades

### DIFF
--- a/Foqos/Models/Shared.swift
+++ b/Foqos/Models/Shared.swift
@@ -54,6 +54,14 @@ enum SharedData {
     var enableEmergencyUnblock: Bool?
   }
 
+  private struct FailableDecodable<Value: Decodable>: Decodable {
+    let value: Value?
+
+    init(from decoder: Decoder) throws {
+      value = try? Value(from: decoder)
+    }
+  }
+
   // MARK: – Serializable snapshot of a session (no profile object)
   struct SessionSnapshot: Codable, Equatable {
     var id: String
@@ -77,7 +85,7 @@ enum SharedData {
   static var profileSnapshots: [String: ProfileSnapshot] {
     get {
       guard let data = suite.data(forKey: Key.profileSnapshots.rawValue) else { return [:] }
-      return (try? JSONDecoder().decode([String: ProfileSnapshot].self, from: data)) ?? [:]
+      return decodeProfileSnapshots(from: data)
     }
     set {
       if let data = try? JSONEncoder().encode(newValue) {
@@ -86,6 +94,14 @@ enum SharedData {
         suite.removeObject(forKey: Key.profileSnapshots.rawValue)
       }
     }
+  }
+
+  static func decodeProfileSnapshots(from data: Data) -> [String: ProfileSnapshot] {
+    let decoded = try? JSONDecoder().decode(
+      [String: FailableDecodable<ProfileSnapshot>].self,
+      from: data
+    )
+    return decoded?.compactMapValues(\.value) ?? [:]
   }
 
   static func snapshot(for profileID: String) -> ProfileSnapshot? {
@@ -224,5 +240,122 @@ enum SharedData {
 
   static func setPauseEndTime(date: Date) {
     activeSharedSession?.pauseEndTime = date
+  }
+}
+
+extension SharedData.ProfileSnapshot {
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case selectedActivity
+    case createdAt
+    case updatedAt
+    case blockingStrategyId
+    case strategyData
+    case order
+    case enableLiveActivity
+    case reminderTimeInSeconds
+    case customReminderMessage
+    case enableBreaks
+    case breakTimeInMinutes
+    case allowMultipleBreaks
+    case enableStrictMode
+    case enableBlockAppInstallation
+    case enableAllowMode
+    case enableAllowModeDomains
+    case enableSafariBlocking
+    case enableAdultContentBlocking
+    case enableMacSync
+    case domains
+    case physicalUnblockNFCTagId
+    case physicalUnblockQRCodeId
+    case physicalUnblockItems
+    case schedule
+    case disableBackgroundStops
+    case enableEmergencyUnblock
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    // Later profile settings use their model defaults when decoding snapshots from older releases.
+    self.init(
+      id: try container.decode(UUID.self, forKey: .id),
+      name: try container.decode(String.self, forKey: .name),
+      selectedActivity: try container.decode(
+        FamilyActivitySelection.self,
+        forKey: .selectedActivity
+      ),
+      createdAt: try container.decode(Date.self, forKey: .createdAt),
+      updatedAt: try container.decode(Date.self, forKey: .updatedAt),
+      blockingStrategyId: try container.decodeIfPresent(
+        String.self,
+        forKey: .blockingStrategyId
+      ),
+      strategyData: try container.decodeIfPresent(Data.self, forKey: .strategyData),
+      order: try container.decode(Int.self, forKey: .order),
+      enableLiveActivity: try container.decode(Bool.self, forKey: .enableLiveActivity),
+      reminderTimeInSeconds: try container.decodeIfPresent(
+        UInt32.self,
+        forKey: .reminderTimeInSeconds
+      ),
+      customReminderMessage: try container.decodeIfPresent(
+        String.self,
+        forKey: .customReminderMessage
+      ),
+      enableBreaks: try container.decode(Bool.self, forKey: .enableBreaks),
+      breakTimeInMinutes: try container.decodeIfPresent(
+        Int.self,
+        forKey: .breakTimeInMinutes
+      ) ?? 15,
+      allowMultipleBreaks: try container.decodeIfPresent(
+        Bool.self,
+        forKey: .allowMultipleBreaks
+      ),
+      enableStrictMode: try container.decode(Bool.self, forKey: .enableStrictMode),
+      enableBlockAppInstallation: try container.decodeIfPresent(
+        Bool.self,
+        forKey: .enableBlockAppInstallation
+      ) ?? false,
+      enableAllowMode: try container.decode(Bool.self, forKey: .enableAllowMode),
+      enableAllowModeDomains: try container.decode(
+        Bool.self,
+        forKey: .enableAllowModeDomains
+      ),
+      enableSafariBlocking: try container.decodeIfPresent(
+        Bool.self,
+        forKey: .enableSafariBlocking
+      ) ?? true,
+      enableAdultContentBlocking: try container.decodeIfPresent(
+        Bool.self,
+        forKey: .enableAdultContentBlocking
+      ),
+      enableMacSync: try container.decodeIfPresent(Bool.self, forKey: .enableMacSync),
+      domains: try container.decodeIfPresent([String].self, forKey: .domains),
+      physicalUnblockNFCTagId: try container.decodeIfPresent(
+        String.self,
+        forKey: .physicalUnblockNFCTagId
+      ),
+      physicalUnblockQRCodeId: try container.decodeIfPresent(
+        String.self,
+        forKey: .physicalUnblockQRCodeId
+      ),
+      physicalUnblockItems: try container.decodeIfPresent(
+        [PhysicalUnblockItem].self,
+        forKey: .physicalUnblockItems
+      ),
+      schedule: try container.decodeIfPresent(
+        BlockedProfileSchedule.self,
+        forKey: .schedule
+      ),
+      disableBackgroundStops: try container.decodeIfPresent(
+        Bool.self,
+        forKey: .disableBackgroundStops
+      ),
+      enableEmergencyUnblock: try container.decodeIfPresent(
+        Bool.self,
+        forKey: .enableEmergencyUnblock
+      )
+    )
   }
 }

--- a/foqosTests/SharedProfileSnapshotTests.swift
+++ b/foqosTests/SharedProfileSnapshotTests.swift
@@ -1,0 +1,165 @@
+import FamilyControls
+import Foundation
+import XCTest
+
+@testable import foqos
+
+final class SharedProfileSnapshotTests: XCTestCase {
+  func testGivenV124Snapshot_WhenDecoded_ThenUsesCurrentDefaults() throws {
+    let snapshot = makeSnapshot()
+    let data = try encodedCollection(
+      containing: snapshot,
+      removing: [
+        "breakTimeInMinutes",
+        "enableSafariBlocking",
+        "enableBlockAppInstallation",
+      ]
+    )
+
+    let decoded = try XCTUnwrap(
+      SharedData.decodeProfileSnapshots(from: data)[snapshot.id.uuidString]
+    )
+
+    XCTAssertEqual(decoded.id, snapshot.id)
+    XCTAssertEqual(decoded.name, snapshot.name)
+    XCTAssertEqual(decoded.breakTimeInMinutes, 15)
+    XCTAssertTrue(decoded.enableSafariBlocking)
+    XCTAssertFalse(decoded.enableBlockAppInstallation)
+  }
+
+  func testGivenV1251Snapshot_WhenDecoded_ThenPreservesBreakDuration() throws {
+    let snapshot = makeSnapshot()
+    let data = try encodedCollection(
+      containing: snapshot,
+      removing: ["enableSafariBlocking", "enableBlockAppInstallation"]
+    )
+
+    let decoded = try XCTUnwrap(
+      SharedData.decodeProfileSnapshots(from: data)[snapshot.id.uuidString]
+    )
+
+    XCTAssertEqual(decoded.breakTimeInMinutes, snapshot.breakTimeInMinutes)
+    XCTAssertTrue(decoded.enableSafariBlocking)
+    XCTAssertFalse(decoded.enableBlockAppInstallation)
+  }
+
+  func testGivenV1324Snapshot_WhenDecoded_ThenPreservesSafariSetting() throws {
+    let snapshot = makeSnapshot()
+    let data = try encodedCollection(
+      containing: snapshot,
+      removing: ["enableBlockAppInstallation"]
+    )
+
+    let decoded = try XCTUnwrap(
+      SharedData.decodeProfileSnapshots(from: data)[snapshot.id.uuidString]
+    )
+
+    XCTAssertEqual(decoded.breakTimeInMinutes, snapshot.breakTimeInMinutes)
+    XCTAssertEqual(decoded.enableSafariBlocking, snapshot.enableSafariBlocking)
+    XCTAssertFalse(decoded.enableBlockAppInstallation)
+  }
+
+  func testGivenCurrentSnapshot_WhenRoundTripped_ThenPreservesExplicitValues() throws {
+    let snapshot = makeSnapshot()
+    let data = try JSONEncoder().encode([snapshot.id.uuidString: snapshot])
+
+    let decoded = SharedData.decodeProfileSnapshots(from: data)
+
+    XCTAssertEqual(decoded[snapshot.id.uuidString], snapshot)
+  }
+
+  func testGivenMalformedSibling_WhenCollectionDecoded_ThenKeepsValidSnapshot() throws {
+    let validSnapshot = makeSnapshot(
+      id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!
+    )
+    let malformedSnapshot = makeSnapshot(
+      id: UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!
+    )
+    let encoded = try JSONEncoder().encode([
+      validSnapshot.id.uuidString: validSnapshot,
+      malformedSnapshot.id.uuidString: malformedSnapshot,
+    ])
+    var collection = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: encoded) as? [String: [String: Any]]
+    )
+    collection[malformedSnapshot.id.uuidString]?.removeValue(forKey: "id")
+
+    let data = try JSONSerialization.data(withJSONObject: collection)
+    let decoded = SharedData.decodeProfileSnapshots(from: data)
+
+    XCTAssertEqual(decoded, [validSnapshot.id.uuidString: validSnapshot])
+  }
+
+  func testGivenMalformedTopLevelData_WhenDecoded_ThenReturnsEmptyCollection() {
+    let decoded = SharedData.decodeProfileSnapshots(from: Data("[]".utf8))
+
+    XCTAssertTrue(decoded.isEmpty)
+  }
+
+  private func makeSnapshot(
+    id: UUID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+  ) -> SharedData.ProfileSnapshot {
+    SharedData.ProfileSnapshot(
+      id: id,
+      name: "Focus",
+      selectedActivity: FamilyActivitySelection(),
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+      updatedAt: Date(timeIntervalSince1970: 1_700_000_100),
+      blockingStrategyId: "manual",
+      strategyData: Data([0x01, 0x02]),
+      order: 2,
+      enableLiveActivity: true,
+      reminderTimeInSeconds: 300,
+      customReminderMessage: "Stay focused",
+      enableBreaks: true,
+      breakTimeInMinutes: 30,
+      allowMultipleBreaks: true,
+      enableStrictMode: true,
+      enableBlockAppInstallation: true,
+      enableAllowMode: false,
+      enableAllowModeDomains: false,
+      enableSafariBlocking: false,
+      enableAdultContentBlocking: true,
+      enableMacSync: true,
+      domains: ["example.com"],
+      physicalUnblockNFCTagId: "legacy-nfc",
+      physicalUnblockQRCodeId: "legacy-qr",
+      physicalUnblockItems: [
+        PhysicalUnblockItem(
+          id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+          name: "Desk tag",
+          type: .nfc,
+          codeValue: "desk-tag"
+        )
+      ],
+      schedule: BlockedProfileSchedule(
+        days: [.monday, .friday],
+        startHour: 9,
+        startMinute: 30,
+        endHour: 11,
+        endMinute: 0,
+        updatedAt: Date(timeIntervalSince1970: 1_700_000_050)
+      ),
+      disableBackgroundStops: true,
+      enableEmergencyUnblock: false
+    )
+  }
+
+  private func encodedCollection(
+    containing snapshot: SharedData.ProfileSnapshot,
+    removing keys: [String]
+  ) throws -> Data {
+    let encoded = try JSONEncoder().encode([snapshot.id.uuidString: snapshot])
+    var collection = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: encoded) as? [String: [String: Any]]
+    )
+    var storedSnapshot = try XCTUnwrap(collection[snapshot.id.uuidString])
+
+    for key in keys {
+      storedSnapshot.removeValue(forKey: key)
+    }
+
+    collection[snapshot.id.uuidString] = storedSnapshot
+    return try JSONSerialization.data(withJSONObject: collection)
+  }
+}


### PR DESCRIPTION
## Summary

- Decode shared profile snapshots created before newer profile settings were added.
- Recover valid snapshots independently when another entry is malformed.
- Add regression coverage for historical release payloads and mixed valid/invalid collections.

## Why

Profile snapshots are stored as JSON in the App Group so widgets and DeviceActivity extensions can resolve profile settings without accessing SwiftData.

`ProfileSnapshot` gained three non-optional properties after snapshot persistence shipped. Swift's synthesized `Decodable` does not use property initializers when a key is absent, so snapshots written by older releases fail with `keyNotFound`.

The current collection decoder converts any entry failure into an empty dictionary. Extensions can then fail to resolve every profile, and a later read-modify-write can replace the derived snapshot map with only the newly written entry. Canonical SwiftData profiles are not deleted.

## Compatibility defaults

Missing fields use the same defaults as `BlockedProfiles`, preserving the behavior users had before each setting was introduced:

- `breakTimeInMinutes`: `15`
- `enableSafariBlocking`: `true`
- `enableBlockAppInstallation`: `false`

Explicit values in current snapshots remain unchanged.

## Tests

- Decode a v1.24.3-shaped snapshot without any of the three later fields.
- Decode a v1.25.1-shaped snapshot without Safari or app-install settings.
- Decode a v1.32.4-shaped snapshot without the app-install setting.
- Round-trip every field in the current snapshot schema, including explicit non-default values.
- Keep a valid snapshot when a sibling entry is malformed.
- Return an empty collection for malformed top-level data.

## Scope

This changes only decoding of the derived App Group snapshot data. It does not modify the SwiftData schema or canonical profile records.

## Validation

- `make lint` (completed; changed files have no format findings)
- `make build`
- `make test` (53 tests passed)
- `make mac-test` (11 tests passed)
- `git diff --check`
