### PR TITLE
Declare required-reason API use for iOS bundles

### DIFF
--- a/Foqos/PrivacyInfo.xcprivacy
+++ b/Foqos/PrivacyInfo.xcprivacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>CA92.1</string>
+        <string>1C8F.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/FoqosDeviceMonitor/PrivacyInfo.xcprivacy
+++ b/FoqosDeviceMonitor/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>1C8F.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/FoqosShieldAction/PrivacyInfo.xcprivacy
+++ b/FoqosShieldAction/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>1C8F.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/FoqosShieldConfig/PrivacyInfo.xcprivacy
+++ b/FoqosShieldConfig/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>1C8F.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/FoqosWidget/PrivacyInfo.xcprivacy
+++ b/FoqosWidget/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>1C8F.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- add an app privacy manifest to the iOS app and each embedded extension
- declare app-private and App Group `UserDefaults` access with Apple's approved reasons
- keep each bundle's declaration limited to the API access it actually performs

## Why

Foqos uses `UserDefaults.standard` in the host app and an App Group suite to share state with its Device Activity, widget, shield configuration, and shield action extensions. Apple requires apps that use required-reason APIs to declare an approved reason in a bundled `PrivacyInfo.xcprivacy` file.

The host app declares:

- `CA92.1` for app-private defaults
- `1C8F.1` for defaults shared within `group.dev.ambitionsoftware.foqos`

Each extension declares only `1C8F.1`, because extension-side access is limited to the App Group suite.

## Scope

This PR intentionally does not add data-collection or tracking declarations; those describe separate privacy practices and should not be inferred from required-reason API use. A macOS manifest is also outside this change because Apple's required-reason API declaration scope currently excludes macOS.

The project uses filesystem-synchronized Xcode groups, so no project-file edit is needed. The build confirms Xcode places one manifest at the app root and one in each embedded extension bundle.

## Validation

- `plutil -lint` on all five source manifests
- `make lint` (passes with existing warnings in unrelated Swift files)
- `make test` — 47 tests passed
- `make mac-test` — 11 tests passed
- `make build`
- verified all five built Foqos manifests are present in the expected `.app` and `.appex` bundle roots and byte-match their sources
- `git diff --check`

## References

- [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy-manifest-files)
- [Approved reasons for required-reason APIs](https://developer.apple.com/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitypereasons)
- [App Store Connect required-reason API requirement](https://developer.apple.com/news/upcoming-requirements/?id=05012024a)
