### PR TITLE
Preserve profile integrity when duplicating

### DIFF
--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -516,6 +516,9 @@ class BlockedProfiles {
     newName: String
   ) throws -> BlockedProfiles {
     let nextOrder = getNextOrder(in: context)
+    var clonedSchedule = source.schedule
+    clonedSchedule?.updatedAt = Date()
+
     let cloned = BlockedProfiles(
       name: newName,
       selectedActivity: source.selectedActivity,
@@ -538,12 +541,14 @@ class BlockedProfiles {
       order: nextOrder,
       domains: source.domains,
       physicalUnblockItems: source.physicalUnblockItems,
-      schedule: source.schedule,
+      schedule: clonedSchedule,
+      disableBackgroundStops: source.disableBackgroundStops,
       enableEmergencyUnblock: source.enableEmergencyUnblock
     )
 
     context.insert(cloned)
     try context.save()
+    updateSnapshot(for: cloned)
     return cloned
   }
 

--- a/foqosTests/BlockedProfilesCloneTests.swift
+++ b/foqosTests/BlockedProfilesCloneTests.swift
@@ -1,0 +1,88 @@
+import SwiftData
+import XCTest
+
+@testable import foqos
+
+@MainActor
+final class BlockedProfilesCloneTests: XCTestCase {
+  func testCloneProfilePreservesBackgroundStopProtection() throws {
+    let context = try makeContext()
+    let source = BlockedProfiles(
+      name: "Protected",
+      blockingStrategyId: NFCBlockingStrategy.id,
+      disableBackgroundStops: true
+    )
+    context.insert(source)
+    try context.save()
+
+    let cloned = try BlockedProfiles.cloneProfile(
+      source,
+      in: context,
+      newName: "Protected Copy"
+    )
+    defer { SharedData.removeSnapshot(for: cloned.id.uuidString) }
+
+    XCTAssertTrue(cloned.disableBackgroundStops)
+  }
+
+  func testCloneProfilePublishesSnapshotForExtensions() throws {
+    let context = try makeContext()
+    let source = BlockedProfiles(
+      name: "Scheduled",
+      blockingStrategyId: QRCodeBlockingStrategy.id,
+      disableBackgroundStops: true,
+      enableEmergencyUnblock: false
+    )
+    context.insert(source)
+    try context.save()
+
+    let cloned = try BlockedProfiles.cloneProfile(
+      source,
+      in: context,
+      newName: "Scheduled Copy"
+    )
+    defer { SharedData.removeSnapshot(for: cloned.id.uuidString) }
+
+    let snapshot = SharedData.snapshot(for: cloned.id.uuidString)
+    XCTAssertEqual(snapshot, BlockedProfiles.getSnapshot(for: cloned))
+  }
+
+  func testCloneProfileTreatsCopiedScheduleAsNew() throws {
+    let context = try makeContext()
+    let sourceScheduleUpdatedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+    let source = BlockedProfiles(
+      name: "Scheduled",
+      schedule: BlockedProfileSchedule(
+        days: [.monday, .friday],
+        startHour: 9,
+        startMinute: 0,
+        endHour: 17,
+        endMinute: 0,
+        updatedAt: sourceScheduleUpdatedAt
+      )
+    )
+    context.insert(source)
+    try context.save()
+
+    let cloned = try BlockedProfiles.cloneProfile(
+      source,
+      in: context,
+      newName: "Scheduled Copy"
+    )
+    defer { SharedData.removeSnapshot(for: cloned.id.uuidString) }
+
+    XCTAssertEqual(source.schedule?.updatedAt, sourceScheduleUpdatedAt)
+    XCTAssertGreaterThan(cloned.schedule?.updatedAt ?? .distantPast, sourceScheduleUpdatedAt)
+    XCTAssertEqual(SharedData.snapshot(for: cloned.id.uuidString)?.schedule, cloned.schedule)
+  }
+
+  private func makeContext() throws -> ModelContext {
+    let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+      for: BlockedProfileSession.self,
+      BlockedProfiles.self,
+      configurations: configuration
+    )
+    return ModelContext(container)
+  }
+}


### PR DESCRIPTION
## Summary

- preserve the background-stop safeguard when duplicating a profile
- refresh copied schedule metadata so cloned schedules retain the existing new-schedule debounce
- publish the saved clone snapshot before its schedule is registered, allowing extensions to resolve it immediately

## Why

Duplicating a profile previously skipped the `disableBackgroundStops` safeguard. It also saved the clone without updating App Group shared state, even though the UI immediately registers a copied DeviceActivity schedule. Extension callbacks could therefore arrive before `TimerActivityUtil` could resolve the cloned profile.

The copied schedule timestamp is refreshed so a newly registered clone continues to receive the existing 15-minute protection against immediately starting a schedule.

## Tests

- `make lint`
- `make test` (50 tests)
- `make mac-test` (11 tests)
- `make build`
- `git diff --check`