### PR TITLE
Disable Allow Mode for Temporary Access

### DIFF
--- a/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileDraft.swift
@@ -37,7 +37,7 @@ final class BlockedProfileDraft: ObservableObject {
         askForStartSettings = true
       }
 
-      enforceStrategyBreaksPolicy()
+      enforceStrategyPolicies()
     }
   }
 
@@ -88,7 +88,7 @@ final class BlockedProfileDraft: ObservableObject {
     strategyData = profile?.strategyData
     askForStartSettings = profile?.askForStartSettings ?? true
 
-    enforceStrategyBreaksPolicy()
+    enforceStrategyPolicies()
   }
 
   var isValid: Bool {
@@ -97,6 +97,10 @@ final class BlockedProfileDraft: ObservableObject {
 
   var selectedStrategyAllowsTimedBreaks: Bool {
     return selectedStrategy?.allowsTimedBreaks ?? true
+  }
+
+  var selectedStrategySupportsAllowMode: Bool {
+    return selectedStrategy?.supportsAllowMode ?? true
   }
 
   func save(
@@ -176,13 +180,16 @@ final class BlockedProfileDraft: ObservableObject {
     return newProfile
   }
 
-  private func enforceStrategyBreaksPolicy() {
-    if selectedStrategyAllowsTimedBreaks {
-      return
+  private func enforceStrategyPolicies() {
+    if !selectedStrategyAllowsTimedBreaks {
+      enableBreaks = false
+      allowMultipleBreaks = false
     }
 
-    enableBreaks = false
-    allowMultipleBreaks = false
+    if !selectedStrategySupportsAllowMode && enableAllowMode {
+      enableAllowMode = false
+      selectedActivity = FamilyActivitySelection()
+    }
   }
 
   private func ensureSavedStartSettings() {

--- a/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileFormSections.swift
@@ -139,7 +139,9 @@ struct BlockedProfileAppsFields: View {
       description:
         "Only selected apps stay available during sessions. Turning this on clears your blocked-app selection.",
       isOn: $draft.enableAllowMode,
-      isDisabled: disabled
+      isDisabled: disabled || !draft.selectedStrategySupportsAllowMode,
+      errorMessage: draft.selectedStrategySupportsAllowMode
+        ? nil : "Allow-only mode isn't supported with Temporary Access."
     )
 
     ProfileFieldDivider(isVisible: showsSeparators)

--- a/Foqos/Models/Strategies/BlockingStrategy.swift
+++ b/Foqos/Models/Strategies/BlockingStrategy.swift
@@ -22,6 +22,7 @@ protocol BlockingStrategy {
   var startsManually: Bool { get }
   var requiresSameCodeToStop: Bool { get }
   var allowsTimedBreaks: Bool { get }
+  var supportsAllowMode: Bool { get }
   var isBeta: Bool { get }
   var startViewPresentationDetents: Set<PresentationDetent> { get }
 
@@ -130,6 +131,7 @@ extension BlockingStrategy {
   var startsManually: Bool { false }
   var requiresSameCodeToStop: Bool { false }
   var allowsTimedBreaks: Bool { true }
+  var supportsAllowMode: Bool { true }
   var isBeta: Bool { false }
   var startViewPresentationDetents: Set<PresentationDetent> { [.medium, .large] }
 

--- a/Foqos/Models/Strategies/NFCSoftUnblockBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/NFCSoftUnblockBlockingStrategy.swift
@@ -14,6 +14,7 @@ final class NFCSoftUnblockBlockingStrategy: BlockingStrategy {
   var usesNFC: Bool = true
   var startsManually: Bool = true
   var allowsTimedBreaks: Bool = false
+  var supportsAllowMode: Bool = false
   var startViewPresentationDetents: Set<PresentationDetent> = [.large]
 
   var onSessionCreation: ((SessionStatus) -> Void)?

--- a/Foqos/Models/Strategies/QRSoftUnblockBlockingStrategy.swift
+++ b/Foqos/Models/Strategies/QRSoftUnblockBlockingStrategy.swift
@@ -14,6 +14,7 @@ final class QRSoftUnblockBlockingStrategy: BlockingStrategy {
   var usesQRCode: Bool = true
   var startsManually: Bool = true
   var allowsTimedBreaks: Bool = false
+  var supportsAllowMode: Bool = false
   var startViewPresentationDetents: Set<PresentationDetent> = [.large]
 
   var onSessionCreation: ((SessionStatus) -> Void)?

--- a/foqosTests/BlockedProfileDraftTests.swift
+++ b/foqosTests/BlockedProfileDraftTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+@testable import foqos
+
+final class BlockedProfileDraftTests: XCTestCase {
+  func testSelectingTemporaryAccessDisablesAllowMode() {
+    let draft = BlockedProfileDraft()
+    draft.enableAllowMode = true
+
+    draft.selectedStrategy = NFCSoftUnblockBlockingStrategy()
+
+    XCTAssertFalse(draft.enableAllowMode)
+    XCTAssertFalse(draft.selectedStrategySupportsAllowMode)
+  }
+
+  func testLoadingTemporaryAccessProfileDisablesAllowMode() {
+    let profile = BlockedProfiles(
+      name: "Temporary Access",
+      blockingStrategyId: QRSoftUnblockBlockingStrategy.id,
+      enableAllowMode: true
+    )
+
+    let draft = BlockedProfileDraft(profile: profile)
+
+    XCTAssertFalse(draft.enableAllowMode)
+    XCTAssertFalse(draft.selectedStrategySupportsAllowMode)
+  }
+
+  func testOtherStrategiesContinueToSupportAllowMode() {
+    let draft = BlockedProfileDraft()
+
+    draft.enableAllowMode = true
+
+    XCTAssertTrue(draft.enableAllowMode)
+    XCTAssertTrue(draft.selectedStrategySupportsAllowMode)
+  }
+}


### PR DESCRIPTION
## Summary

- mark Temporary Access strategies as incompatible with Allow Mode
- disable the Allow Mode toggle and explain why it is unavailable
- clean up incompatible draft state when switching strategies or opening an older profile
- add regression tests for NFC, QR, and supported strategies

## Testing

- make test (42 tests passed)
- make build
- make lint (completed with existing warnings in unrelated files)

fixes: #507 