### PR TITLE
Fix pausing profiles started from Shortcuts

### DIFF
--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -318,7 +318,7 @@ class StrategyManager: ObservableObject {
     let profile = session.blockedProfile
     let profileName = profile.name
     let strategy = StrategyManager.availableStrategies.first {
-      $0.getIdentifier() == session.tag
+      $0.getIdentifier() == profile.blockingStrategyId
     }
 
     guard strategy?.hasPauseMode == true else {

--- a/foqosTests/PauseActiveSessionTests.swift
+++ b/foqosTests/PauseActiveSessionTests.swift
@@ -40,6 +40,25 @@ final class PauseActiveSessionTests: XCTestCase {
     XCTAssertEqual(scheduledProfileId, profile.id)
   }
 
+  func testShortcutStartedNFCPauseStrategySchedulesPause() throws {
+    let context = try makeContext()
+    let profile = try makeActiveSession(
+      strategyId: NFCPauseTimerBlockingStrategy.id,
+      sessionTag: ManualBlockingStrategy.id,
+      forceStart: true,
+      context: context
+    ).blockedProfile
+    var scheduledProfileId: UUID?
+
+    let profileName = try StrategyManager().pauseActiveSessionFromBackground(
+      context: context,
+      schedulePause: { scheduledProfileId = $0.id }
+    )
+
+    XCTAssertEqual(profileName, profile.name)
+    XCTAssertEqual(scheduledProfileId, profile.id)
+  }
+
   func testQRPauseStrategySchedulesPause() throws {
     let context = try makeContext()
     let profile = try makeActiveSession(
@@ -203,6 +222,8 @@ final class PauseActiveSessionTests: XCTestCase {
 
   private func makeActiveSession(
     strategyId: String,
+    sessionTag: String? = nil,
+    forceStart: Bool = false,
     includePauseConfiguration: Bool = true,
     enableBreaks: Bool = false,
     context: ModelContext
@@ -222,8 +243,9 @@ final class PauseActiveSessionTests: XCTestCase {
 
     let session = BlockedProfileSession.createSession(
       in: context,
-      withTag: strategyId,
-      withProfile: profile
+      withTag: sessionTag ?? strategyId,
+      withProfile: profile,
+      forceStart: forceStart
     )
     try context.save()
     return session


### PR DESCRIPTION
## Summary

- resolve pause support from the profile's configured strategy instead of the overloaded session tag
- add regression coverage for force-started NFC + Pause sessions created through Shortcuts

## Testing

- `make test UNIT_TEST_TARGET=foqosTests/PauseActiveSessionTests`
- `swift-format lint Foqos/Utils/StrategyManager.swift foqosTests/PauseActiveSessionTests.swift`

Closes #514